### PR TITLE
Implement gravity paint zones for side scrolling character

### DIFF
--- a/Source/GameJam/Variant_SideScrolling/Gameplay/PaintZone.cpp
+++ b/Source/GameJam/Variant_SideScrolling/Gameplay/PaintZone.cpp
@@ -1,0 +1,192 @@
+#include "Gameplay/PaintZone.h"
+
+#include "Components/BoxComponent.h"
+#include "Components/DecalComponent.h"
+#include "Components/PrimitiveComponent.h"
+#include "GameFramework/Character.h"
+#include "GameFramework/CharacterMovementComponent.h"
+#include "Materials/MaterialInstanceDynamic.h"
+#include "Math/RotationMatrix.h"
+
+APaintZone::APaintZone()
+{
+    PrimaryActorTick.bCanEverTick = true;
+
+    SceneRoot = CreateDefaultSubobject<USceneComponent>(TEXT("Root"));
+    SetRootComponent(SceneRoot);
+
+    DecalComponent = CreateDefaultSubobject<UDecalComponent>(TEXT("Decal"));
+    DecalComponent->SetupAttachment(SceneRoot);
+    DecalComponent->DecalSize = FVector(32.0f, 128.0f, 128.0f);
+    DecalComponent->SetFadeScreenSize(0.001f);
+
+    OverlapComponent = CreateDefaultSubobject<UBoxComponent>(TEXT("ForceVolume"));
+    OverlapComponent->SetupAttachment(SceneRoot);
+    OverlapComponent->SetBoxExtent(FVector(120.0f));
+    OverlapComponent->SetCollisionEnabled(ECollisionEnabled::QueryOnly);
+    OverlapComponent->SetCollisionResponseToAllChannels(ECR_Ignore);
+    OverlapComponent->SetCollisionResponseToChannel(ECC_Pawn, ECR_Overlap);
+    OverlapComponent->SetCollisionResponseToChannel(ECC_PhysicsBody, ECR_Overlap);
+    OverlapComponent->SetGenerateOverlapEvents(true);
+
+    bReplicates = true;
+}
+
+void APaintZone::InitializePaintZone(EForceType InForceType, const FVector& InSurfaceNormal, bool bInPermanent)
+{
+    ForceType = InForceType;
+    SurfaceNormal = InSurfaceNormal.IsNearlyZero() ? FVector::UpVector : InSurfaceNormal.GetSafeNormal();
+    bPermanent = bInPermanent;
+
+    if (!bPermanent)
+    {
+        if (DecalComponent)
+        {
+            DecalComponent->SetFadeOut(LifeTime, FadeOutDuration, false);
+        }
+        SetLifeSpan(LifeTime + FadeOutDuration);
+    }
+    else
+    {
+        if (DecalComponent)
+        {
+            DecalComponent->SetFadeOut(0.0f, 0.0f, false);
+        }
+        SetLifeSpan(0.0f);
+    }
+
+    UpdateVisuals();
+}
+
+void APaintZone::BeginPlay()
+{
+    Super::BeginPlay();
+
+    UpdateVisuals();
+}
+
+void APaintZone::Tick(float DeltaSeconds)
+{
+    Super::Tick(DeltaSeconds);
+
+    ElapsedTime += DeltaSeconds;
+
+    const bool bForcesExpired = (!bPermanent && ElapsedTime > LifeTime);
+    if (!bForcesExpired)
+    {
+        ApplyForces(DeltaSeconds);
+    }
+}
+
+void APaintZone::UpdateVisuals()
+{
+    if (!DecalComponent)
+    {
+        return;
+    }
+
+    // Align the decal so that its forward vector matches the surface normal.
+    const FRotationMatrix RotationMatrix = FRotationMatrix::MakeFromZ(SurfaceNormal);
+    SetActorRotation(RotationMatrix.Rotator());
+
+    if (!DecalMID)
+    {
+        DecalMID = DecalComponent->CreateDynamicMaterialInstance();
+    }
+
+    if (DecalMID)
+    {
+        FLinearColor DesiredColor = PushColor;
+        switch (ForceType)
+        {
+        case EForceType::Pull:
+            DesiredColor = PullColor;
+            break;
+        case EForceType::Gravity:
+            DesiredColor = GravityColor;
+            break;
+        case EForceType::Push:
+        default:
+            DesiredColor = PushColor;
+            break;
+        }
+
+        DecalMID->SetVectorParameterValue(ColorParameterName, DesiredColor);
+    }
+}
+
+void APaintZone::ApplyForces(float DeltaSeconds)
+{
+    if (!OverlapComponent)
+    {
+        return;
+    }
+
+    TArray<AActor*> OverlappingActors;
+    OverlapComponent->GetOverlappingActors(OverlappingActors);
+
+    if (OverlappingActors.IsEmpty())
+    {
+        return;
+    }
+
+    const float Strength = (ForceType == EForceType::Gravity) ? GravityStrength : ForceStrength;
+
+    FVector ForceDirection = SurfaceNormal;
+    if (ForceType == EForceType::Pull || ForceType == EForceType::Gravity)
+    {
+        ForceDirection *= -1.0f;
+    }
+
+    const FVector Acceleration = ForceDirection * Strength;
+
+    for (AActor* Actor : OverlappingActors)
+    {
+        if (!Actor || Actor == this)
+        {
+            continue;
+        }
+
+        bool bAppliedForce = false;
+
+        // Handle characters explicitly.
+        if (ACharacter* Character = Cast<ACharacter>(Actor))
+        {
+            if (UCharacterMovementComponent* MovementComponent = Character->GetCharacterMovement())
+            {
+                MovementComponent->AddForce(Acceleration * MovementComponent->Mass);
+                bAppliedForce = true;
+            }
+        }
+
+        // Apply force to any simulating components the actor owns.
+        TArray<UPrimitiveComponent*> PrimitiveComponents;
+        Actor->GetComponents(PrimitiveComponents);
+        for (UPrimitiveComponent* PrimitiveComponent : PrimitiveComponents)
+        {
+            if (!PrimitiveComponent || !PrimitiveComponent->IsSimulatingPhysics())
+            {
+                continue;
+            }
+
+            PrimitiveComponent->AddForce(Acceleration * PrimitiveComponent->GetMass(), NAME_None, true);
+            bAppliedForce = true;
+        }
+
+        if (!bAppliedForce && ForceType == EForceType::Gravity)
+        {
+            // For non-physics actors (like pawns) that lack simulation, apply a small impulse to mimic pull.
+            if (UPrimitiveComponent* RootPrimitive = Cast<UPrimitiveComponent>(Actor->GetRootComponent()))
+            {
+                if (RootPrimitive->IsSimulatingPhysics())
+                {
+                    // Already handled in loop above.
+                    continue;
+                }
+
+                RootPrimitive->AddForce(Acceleration * RootPrimitive->GetMass(), NAME_None, true);
+            }
+        }
+    }
+}
+

--- a/Source/GameJam/Variant_SideScrolling/Gameplay/PaintZone.h
+++ b/Source/GameJam/Variant_SideScrolling/Gameplay/PaintZone.h
@@ -1,0 +1,109 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "Components/SceneComponent.h"
+#include "PaintZone.generated.h"
+
+class UBoxComponent;
+class UDecalComponent;
+class UMaterialInstanceDynamic;
+
+UENUM(BlueprintType)
+enum class EForceType : uint8
+{
+    Push    UMETA(DisplayName = "Push"),
+    Pull    UMETA(DisplayName = "Pull"),
+    Gravity UMETA(DisplayName = "Gravity")
+};
+
+UCLASS()
+class APaintZone : public AActor
+{
+    GENERATED_BODY()
+
+public:
+    APaintZone();
+
+    /** Configures the paint zone after it has been spawned. */
+    void InitializePaintZone(EForceType InForceType, const FVector& InSurfaceNormal, bool bInPermanent);
+
+    /** Returns true if this zone is permanent. */
+    bool IsPermanent() const { return bPermanent; }
+
+protected:
+    virtual void BeginPlay() override;
+    virtual void Tick(float DeltaSeconds) override;
+
+    /** Updates the visual state (color + orientation) of the paint. */
+    void UpdateVisuals();
+
+    /** Applies the configured force to every overlapping actor. */
+    void ApplyForces(float DeltaSeconds);
+
+protected:
+    /** Root component */
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Components")
+    USceneComponent* SceneRoot;
+
+    /** Visual representation of the paint splat. */
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Components")
+    UDecalComponent* DecalComponent;
+
+    /** Collision volume used to determine the affected area. */
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Components")
+    UBoxComponent* OverlapComponent;
+
+    /** Optional dynamic material for tinting and fading. */
+    UPROPERTY(Transient)
+    UMaterialInstanceDynamic* DecalMID;
+
+    /** Force type applied by this zone. */
+    UPROPERTY(BlueprintReadOnly, Category = "Paint Zone")
+    EForceType ForceType = EForceType::Push;
+
+    /** Unit direction that represents the painted surface normal. */
+    UPROPERTY(BlueprintReadOnly, Category = "Paint Zone")
+    FVector SurfaceNormal = FVector::UpVector;
+
+    /** True if this paint zone should never disappear. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Paint Zone")
+    bool bPermanent = false;
+
+    /** Duration before the zone begins to fade out. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Paint Zone", meta = (ClampMin = "0.0", Units = "s"))
+    float LifeTime = 5.0f;
+
+    /** How long the zone takes to fade away after it expires. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Paint Zone", meta = (ClampMin = "0.0", Units = "s"))
+    float FadeOutDuration = 1.0f;
+
+    /** Magnitude of the push/pull forces applied, treated as acceleration (cm/s^2). */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Paint Zone", meta = (ClampMin = "0.0"))
+    float ForceStrength = 2500.0f;
+
+    /** Magnitude of the gravity-altering force, treated as acceleration (cm/s^2). */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Paint Zone", meta = (ClampMin = "0.0"))
+    float GravityStrength = 980.0f;
+
+    /** Color tint used for push zones. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Paint Zone|Visuals")
+    FLinearColor PushColor = FLinearColor::Red;
+
+    /** Color tint used for pull zones. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Paint Zone|Visuals")
+    FLinearColor PullColor = FLinearColor::Blue;
+
+    /** Color tint used for gravity zones. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Paint Zone|Visuals")
+    FLinearColor GravityColor = FLinearColor::Green;
+
+    /** Material parameter used to tint the decal. */
+    UPROPERTY(EditDefaultsOnly, Category = "Paint Zone|Visuals")
+    FName ColorParameterName = TEXT("TintColor");
+
+private:
+    /** Accumulated lifetime for fade/force management. */
+    float ElapsedTime = 0.0f;
+};
+

--- a/Source/GameJam/Variant_SideScrolling/SideScrollingCharacter.h
+++ b/Source/GameJam/Variant_SideScrolling/SideScrollingCharacter.h
@@ -9,6 +9,8 @@
 class UCameraComponent;
 class UInputAction;
 struct FInputActionValue;
+class APaintZone;
+enum class EForceType : uint8;
 
 /**
  *  A player-controllable character side scrolling game
@@ -152,6 +154,10 @@ public:
 	UFUNCTION(BlueprintCallable, Category="Input")
 	virtual void DoInteract();
 
+	/** Fires a paint projectile that creates a gravity/force zone at the impact point. */
+	UFUNCTION(BlueprintCallable, Category="Side Scrolling|Paint")
+	void ShootPaint(EForceType ForceType, bool bMakePermanent = false);
+
 protected:
 
 	/** Handles advanced jump logic */
@@ -177,4 +183,17 @@ public:
 	/** Returns true if the character has just wall jumped */
 	UFUNCTION(BlueprintPure, Category="Side Scrolling")
 	bool HasWallJumped() const;
+
+protected:
+	/** Paint zone class spawned when shooting paint. */
+	UPROPERTY(EditDefaultsOnly, Category="Side Scrolling|Paint")
+	TSubclassOf<APaintZone> PaintZoneClass;
+
+	/** Maximum distance the paint can travel when fired. */
+	UPROPERTY(EditDefaultsOnly, Category="Side Scrolling|Paint")
+	float PaintRange = 2000.0f;
+
+	/** Small offset applied when spawning zones to avoid clipping into the surface. */
+	UPROPERTY(EditDefaultsOnly, Category="Side Scrolling|Paint")
+	float PaintSurfaceOffset = 5.0f;
 };


### PR DESCRIPTION
## Summary
- add an APaintZone actor that represents painted surfaces and applies push, pull, or gravity forces
- add a ShootPaint helper on the side scrolling character to line trace from the camera and spawn paint zones with the correct orientation

## Testing
- not run (Unreal Editor not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d62f171654832e9122d32a202caf07