### PR TITLE
Add paint mechanic input and paint zone initialization

### DIFF
--- a/Source/GameJam/GameJamCharacter.h
+++ b/Source/GameJam/GameJamCharacter.h
@@ -5,12 +5,14 @@
 #include "CoreMinimal.h"
 #include "GameFramework/Character.h"
 #include "Logging/LogMacros.h"
+#include "Variant_SideScrolling/Gameplay/PaintZone.h"
 #include "GameJamCharacter.generated.h"
 
 class USpringArmComponent;
 class UCameraComponent;
 class UInputAction;
 struct FInputActionValue;
+class APaintZone;
 
 DECLARE_LOG_CATEGORY_EXTERN(LogTemplateCharacter, Log, All);
 
@@ -41,18 +43,26 @@ protected:
 	UPROPERTY(EditAnywhere, Category="Input")
 	UInputAction* MoveAction;
 
-	/** Look Input Action */
-	UPROPERTY(EditAnywhere, Category="Input")
-	UInputAction* LookAction;
+        /** Look Input Action */
+        UPROPERTY(EditAnywhere, Category="Input")
+        UInputAction* LookAction;
 
-	/** Mouse Look Input Action */
-	UPROPERTY(EditAnywhere, Category="Input")
-	UInputAction* MouseLookAction;
+        /** Mouse Look Input Action */
+        UPROPERTY(EditAnywhere, Category="Input")
+        UInputAction* MouseLookAction;
+
+        /** Paint Input Action */
+        UPROPERTY(EditAnywhere, Category="Input")
+        UInputAction* PaintAction;
+
+        /** Switch Paint Type Input Action */
+        UPROPERTY(EditAnywhere, Category="Input")
+        UInputAction* SwitchPaintTypeAction;
 
 public:
 
-	/** Constructor */
-	AGameJamCharacter();	
+        /** Constructor */
+        AGameJamCharacter();
 
 protected:
 
@@ -61,11 +71,26 @@ protected:
 
 protected:
 
-	/** Called for movement input */
-	void Move(const FInputActionValue& Value);
+        /** Called for movement input */
+        void Move(const FInputActionValue& Value);
 
-	/** Called for looking input */
-	void Look(const FInputActionValue& Value);
+        /** Called for looking input */
+        void Look(const FInputActionValue& Value);
+
+        /** Fires a paint projectile that creates a paint zone. */
+        void ShootPaint();
+
+        /** Cycles through the available paint force types. */
+        void CyclePaintType(const FInputActionValue& Value);
+
+        UPROPERTY(EditDefaultsOnly, Category="Paint")
+        TSubclassOf<class APaintZone> PaintZoneClass;
+
+        UPROPERTY(EditDefaultsOnly, Category="Paint")
+        float PaintRange = 2000.f;
+
+        UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Paint")
+        EForceType CurrentForceType = EForceType::Push;
 
 public:
 

--- a/Source/GameJam/Variant_SideScrolling/Gameplay/PaintZone.cpp
+++ b/Source/GameJam/Variant_SideScrolling/Gameplay/PaintZone.cpp
@@ -58,6 +58,15 @@ void APaintZone::InitializePaintZone(EForceType InForceType, const FVector& InSu
     UpdateVisuals();
 }
 
+void APaintZone::InitializeFromHit(const FHitResult& Hit, EForceType ForceType)
+{
+    SurfaceNormal = Hit.Normal;
+    this->ForceType = ForceType;
+    SetActorLocation(Hit.Location);
+    SetActorRotation(FRotationMatrix::MakeFromZ(Hit.Normal).Rotator());
+    UpdateVisuals();
+}
+
 void APaintZone::BeginPlay()
 {
     Super::BeginPlay();

--- a/Source/GameJam/Variant_SideScrolling/Gameplay/PaintZone.h
+++ b/Source/GameJam/Variant_SideScrolling/Gameplay/PaintZone.h
@@ -3,6 +3,7 @@
 #include "CoreMinimal.h"
 #include "GameFramework/Actor.h"
 #include "Components/SceneComponent.h"
+#include "Engine/EngineTypes.h"
 #include "PaintZone.generated.h"
 
 class UBoxComponent;
@@ -27,6 +28,9 @@ public:
 
     /** Configures the paint zone after it has been spawned. */
     void InitializePaintZone(EForceType InForceType, const FVector& InSurfaceNormal, bool bInPermanent);
+
+    /** Initializes the zone based on a trace hit. */
+    void InitializeFromHit(const FHitResult& Hit, EForceType ForceType);
 
     /** Returns true if this zone is permanent. */
     bool IsPermanent() const { return bPermanent; }


### PR DESCRIPTION
## Summary
- bind new paint and paint-type input actions on the character using Enhanced Input
- implement paint firing trace that spawns paint zones and cycles force types
- add a helper on paint zones to configure themselves from trace hit data

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d63ab5f9e8832e8aed276a76dce485