### PR TITLE
Implement world shifting gameplay framework

### DIFF
--- a/Source/GameJam/ShiftPlatform.cpp
+++ b/Source/GameJam/ShiftPlatform.cpp
@@ -1,0 +1,11 @@
+#include "ShiftPlatform.h"
+#include "Components/StaticMeshComponent.h"
+#include "WorldShiftComponent.h"
+
+AShiftPlatform::AShiftPlatform()
+{
+    PlatformMesh = CreateDefaultSubobject<UStaticMeshComponent>(TEXT("PlatformMesh"));
+    RootComponent = PlatformMesh;
+
+    WorldShiftComponent = CreateDefaultSubobject<UWorldShiftComponent>(TEXT("WorldShiftComponent"));
+}

--- a/Source/GameJam/ShiftPlatform.h
+++ b/Source/GameJam/ShiftPlatform.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "ShiftPlatform.generated.h"
+
+class UStaticMeshComponent;
+class UWorldShiftComponent;
+
+UCLASS()
+class GAMEJAM_API AShiftPlatform : public AActor
+{
+    GENERATED_BODY()
+
+public:
+    AShiftPlatform();
+
+protected:
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Components")
+    TObjectPtr<UStaticMeshComponent> PlatformMesh;
+
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "World Shift")
+    TObjectPtr<UWorldShiftComponent> WorldShiftComponent;
+};

--- a/Source/GameJam/WorldManager.cpp
+++ b/Source/GameJam/WorldManager.cpp
@@ -1,0 +1,128 @@
+#include "WorldManager.h"
+#include "GameFramework/PlayerController.h"
+#include "Engine/World.h"
+#include "EngineUtils.h"
+#include "InputCoreTypes.h"
+
+TWeakObjectPtr<AWorldManager> AWorldManager::ActiveWorldManager = nullptr;
+
+AWorldManager::AWorldManager()
+{
+    PrimaryActorTick.bCanEverTick = false;
+
+    StartingWorld = EWorldState::Light;
+    CurrentWorld = StartingWorld;
+}
+
+AWorldManager* AWorldManager::Get(UWorld* World)
+{
+    if (ActiveWorldManager.IsValid())
+    {
+        return ActiveWorldManager.Get();
+    }
+
+    if (!World)
+    {
+        return nullptr;
+    }
+
+    for (TActorIterator<AWorldManager> It(World); It; ++It)
+    {
+        if (AWorldManager* Manager = *It)
+        {
+            ActiveWorldManager = Manager;
+            return Manager;
+        }
+    }
+
+    return nullptr;
+}
+
+void AWorldManager::BeginPlay()
+{
+    Super::BeginPlay();
+
+    ActiveWorldManager = this;
+    CurrentWorld = StartingWorld;
+
+    InitializeInput();
+    BroadcastWorldShift();
+}
+
+void AWorldManager::EndPlay(const EEndPlayReason::Type EndPlayReason)
+{
+    if (ActiveWorldManager.Get() == this)
+    {
+        ActiveWorldManager = nullptr;
+    }
+
+    Super::EndPlay(EndPlayReason);
+}
+
+void AWorldManager::InitializeInput()
+{
+    if (APlayerController* PC = GetWorld()->GetFirstPlayerController())
+    {
+        EnableInput(PC);
+
+        if (InputComponent)
+        {
+            InputComponent->BindKey(EKeys::E, IE_Pressed, this, &AWorldManager::ShiftToNextWorld);
+            InputComponent->BindKey(EKeys::Q, IE_Pressed, this, &AWorldManager::ShiftToPreviousWorld);
+        }
+    }
+}
+
+void AWorldManager::SetWorld(EWorldState NewWorld)
+{
+    if (CurrentWorld == NewWorld)
+    {
+        return;
+    }
+
+    CurrentWorld = NewWorld;
+    BroadcastWorldShift();
+}
+
+void AWorldManager::ShiftToNextWorld()
+{
+    SetWorld(GetNextWorld(CurrentWorld));
+}
+
+void AWorldManager::ShiftToPreviousWorld()
+{
+    SetWorld(GetPreviousWorld(CurrentWorld));
+}
+
+void AWorldManager::BroadcastWorldShift()
+{
+    OnWorldShifted.Broadcast(CurrentWorld);
+}
+
+EWorldState AWorldManager::GetNextWorld(EWorldState InWorld)
+{
+    switch (InWorld)
+    {
+    case EWorldState::Light:
+        return EWorldState::Shadow;
+    case EWorldState::Shadow:
+        return EWorldState::Dream;
+    case EWorldState::Dream:
+    default:
+        return EWorldState::Light;
+    }
+}
+
+EWorldState AWorldManager::GetPreviousWorld(EWorldState InWorld)
+{
+    switch (InWorld)
+    {
+    case EWorldState::Light:
+        return EWorldState::Dream;
+    case EWorldState::Shadow:
+        return EWorldState::Light;
+    case EWorldState::Dream:
+    default:
+        return EWorldState::Shadow;
+    }
+}

--- a/Source/GameJam/WorldManager.h
+++ b/Source/GameJam/WorldManager.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "WorldShiftTypes.h"
+#include "WorldManager.generated.h"
+
+UCLASS(BlueprintType)
+class GAMEJAM_API AWorldManager : public AActor
+{
+    GENERATED_BODY()
+
+public:
+    AWorldManager();
+
+    static AWorldManager* Get(UWorld* World);
+
+    UFUNCTION(BlueprintCallable, Category = "World Shift")
+    void SetWorld(EWorldState NewWorld);
+
+    UFUNCTION(BlueprintCallable, Category = "World Shift")
+    void ShiftToNextWorld();
+
+    UFUNCTION(BlueprintCallable, Category = "World Shift")
+    void ShiftToPreviousWorld();
+
+    UFUNCTION(BlueprintPure, Category = "World Shift")
+    EWorldState GetCurrentWorld() const { return CurrentWorld; }
+
+    UPROPERTY(BlueprintAssignable, Category = "World Shift")
+    FOnWorldShifted OnWorldShifted;
+
+protected:
+    virtual void BeginPlay() override;
+    virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
+
+    void InitializeInput();
+
+private:
+    static TWeakObjectPtr<AWorldManager> ActiveWorldManager;
+
+    void BroadcastWorldShift();
+
+    static EWorldState GetNextWorld(EWorldState InWorld);
+    static EWorldState GetPreviousWorld(EWorldState InWorld);
+
+    UPROPERTY(EditAnywhere, Category = "World Shift")
+    EWorldState StartingWorld;
+
+    EWorldState CurrentWorld;
+};

--- a/Source/GameJam/WorldShiftComponent.cpp
+++ b/Source/GameJam/WorldShiftComponent.cpp
@@ -1,0 +1,79 @@
+#include "WorldShiftComponent.h"
+#include "WorldManager.h"
+#include "GameFramework/Actor.h"
+#include "Components/PrimitiveComponent.h"
+
+UWorldShiftComponent::UWorldShiftComponent()
+{
+    PrimaryComponentTick.bCanEverTick = false;
+    VisibleInWorlds.Add(EWorldState::Light);
+}
+
+void UWorldShiftComponent::BeginPlay()
+{
+    Super::BeginPlay();
+
+    BindToWorldManager();
+
+    if (CachedWorldManager.IsValid())
+    {
+        OnWorldShift(CachedWorldManager->GetCurrentWorld());
+    }
+}
+
+void UWorldShiftComponent::EndPlay(const EEndPlayReason::Type EndPlayReason)
+{
+    if (CachedWorldManager.IsValid() && WorldShiftDelegateHandle.IsValid())
+    {
+        CachedWorldManager->OnWorldShifted.Remove(WorldShiftDelegateHandle);
+    }
+
+    Super::EndPlay(EndPlayReason);
+}
+
+void UWorldShiftComponent::OnRegister()
+{
+    Super::OnRegister();
+
+    BindToWorldManager();
+}
+
+void UWorldShiftComponent::BindToWorldManager()
+{
+    if (CachedWorldManager.IsValid())
+    {
+        return;
+    }
+
+    if (AWorldManager* Manager = AWorldManager::Get(GetWorld()))
+    {
+        CachedWorldManager = Manager;
+        WorldShiftDelegateHandle = Manager->OnWorldShifted.AddUObject(this, &UWorldShiftComponent::HandleWorldShift);
+    }
+}
+
+void UWorldShiftComponent::HandleWorldShift(EWorldState NewWorld)
+{
+    OnWorldShift(NewWorld);
+}
+
+void UWorldShiftComponent::OnWorldShift(EWorldState NewWorld)
+{
+    const bool bShouldBeVisible = VisibleInWorlds.Contains(NewWorld);
+
+    if (AActor* Owner = GetOwner())
+    {
+        Owner->SetActorHiddenInGame(!bShouldBeVisible);
+        Owner->SetActorEnableCollision(bShouldBeVisible);
+
+        TArray<UActorComponent*> PrimitiveComponents = Owner->GetComponentsByClass(UPrimitiveComponent::StaticClass());
+        for (UActorComponent* Component : PrimitiveComponents)
+        {
+            if (UPrimitiveComponent* Primitive = Cast<UPrimitiveComponent>(Component))
+            {
+                Primitive->SetHiddenInGame(!bShouldBeVisible);
+                Primitive->SetCollisionEnabled(bShouldBeVisible ? ECollisionEnabled::QueryAndPhysics : ECollisionEnabled::NoCollision);
+            }
+        }
+    }
+}

--- a/Source/GameJam/WorldShiftComponent.h
+++ b/Source/GameJam/WorldShiftComponent.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+#include "WorldShiftTypes.h"
+#include "WorldShiftComponent.generated.h"
+
+class AWorldManager;
+
+UCLASS(ClassGroup = (WorldShift), meta = (BlueprintSpawnableComponent))
+class GAMEJAM_API UWorldShiftComponent : public UActorComponent
+{
+    GENERATED_BODY()
+
+public:
+    UWorldShiftComponent();
+
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "World Shift")
+    TArray<EWorldState> VisibleInWorlds;
+
+    UFUNCTION(BlueprintCallable, Category = "World Shift")
+    void OnWorldShift(EWorldState NewWorld);
+
+protected:
+    virtual void OnRegister() override;
+    virtual void BeginPlay() override;
+    virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
+
+private:
+    void BindToWorldManager();
+    void HandleWorldShift(EWorldState NewWorld);
+
+    TWeakObjectPtr<AWorldManager> CachedWorldManager;
+    FDelegateHandle WorldShiftDelegateHandle;
+};

--- a/Source/GameJam/WorldShiftTypes.h
+++ b/Source/GameJam/WorldShiftTypes.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "WorldShiftTypes.generated.h"
+
+UENUM(BlueprintType)
+enum class EWorldState : uint8
+{
+    Light UMETA(DisplayName = "Light"),
+    Shadow UMETA(DisplayName = "Shadow"),
+    Dream UMETA(DisplayName = "Dream")
+};
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnWorldShifted, EWorldState, NewWorld);


### PR DESCRIPTION
## Summary
- add reusable world state enum and delegate definitions
- implement a world shift component that toggles actor visibility and collision via a central manager
- create a shiftable platform actor and a world manager that cycles through Light, Shadow, and Dream states and broadcasts shifts

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d90a36d96c832eaec3ac66ab634f62