### PR TITLE
Implement world manager system for multi-world gameplay

### DIFF
--- a/Source/GameJam/GameJamCharacter.cpp
+++ b/Source/GameJam/GameJamCharacter.cpp
@@ -15,6 +15,8 @@
 #include "Math/RotationMatrix.h"
 #include "Gameplay/PaintZone.h"
 #include "GameJam.h"
+#include "InputCoreTypes.h"
+#include "WorldManager.h"
 
 AGameJamCharacter::AGameJamCharacter()
 {
@@ -78,6 +80,10 @@ void AGameJamCharacter::SetupPlayerInputComponent(UInputComponent* PlayerInputCo
 
                 // Switching paint type
                 EnhancedInputComponent->BindAction(SwitchPaintTypeAction, ETriggerEvent::Triggered, this, &AGameJamCharacter::CyclePaintType);
+
+                // World shifting
+                EnhancedInputComponent->BindKey(EKeys::E, IE_Pressed, this, &AGameJamCharacter::CycleToNextWorld);
+                EnhancedInputComponent->BindKey(EKeys::Q, IE_Pressed, this, &AGameJamCharacter::CycleToPreviousWorld);
         }
         else
         {
@@ -153,6 +159,30 @@ void AGameJamCharacter::CyclePaintType(const FInputActionValue& Value)
         int32 ForceTypeIndex = static_cast<int32>(CurrentForceType);
         ForceTypeIndex = (ForceTypeIndex + Direction + ForceTypeCount) % ForceTypeCount;
         CurrentForceType = static_cast<EForceType>(ForceTypeIndex);
+}
+
+void AGameJamCharacter::CycleToNextWorld()
+{
+        if (AWorldManager* Manager = AWorldManager::GetWorldManager(this))
+        {
+                Manager->CycleWorld(1);
+        }
+}
+
+void AGameJamCharacter::CycleToPreviousWorld()
+{
+        if (AWorldManager* Manager = AWorldManager::GetWorldManager(this))
+        {
+                Manager->CycleWorld(-1);
+        }
+}
+
+void AGameJamCharacter::ForceSetWorld(EWorldState NewWorld)
+{
+        if (AWorldManager* Manager = AWorldManager::GetWorldManager(this))
+        {
+                Manager->SetWorld(NewWorld);
+        }
 }
 
 void AGameJamCharacter::DoMove(float Right, float Forward)

--- a/Source/GameJam/GameJamCharacter.h
+++ b/Source/GameJam/GameJamCharacter.h
@@ -13,6 +13,8 @@ class UCameraComponent;
 class UInputAction;
 struct FInputActionValue;
 class APaintZone;
+class AWorldManager;
+enum class EWorldState : uint8;
 
 DECLARE_LOG_CATEGORY_EXTERN(LogTemplateCharacter, Log, All);
 
@@ -82,6 +84,16 @@ protected:
 
         /** Cycles through the available paint force types. */
         void CyclePaintType(const FInputActionValue& Value);
+
+        /** Cycle to the next registered world. */
+        void CycleToNextWorld();
+
+        /** Cycle to the previous registered world. */
+        void CycleToPreviousWorld();
+
+        /** Force switch to a particular world state from Blueprints. */
+        UFUNCTION(BlueprintCallable, Category="World")
+        void ForceSetWorld(EWorldState NewWorld);
 
         UPROPERTY(EditDefaultsOnly, Category="Paint")
         TSubclassOf<class APaintZone> PaintZoneClass;

--- a/Source/GameJam/WorldManager.cpp
+++ b/Source/GameJam/WorldManager.cpp
@@ -1,0 +1,101 @@
+#include "WorldManager.h"
+
+#include "Engine/Engine.h"
+#include "Engine/World.h"
+#include "EngineUtils.h"
+#include "WorldShiftComponent.h"
+
+namespace
+{
+    constexpr int32 GetWorldStateCount()
+    {
+        return static_cast<int32>(EWorldState::Dream) + 1;
+    }
+
+    int32 WrapWorldIndex(int32 Index)
+    {
+        const int32 WorldCount = GetWorldStateCount();
+        Index %= WorldCount;
+        if (Index < 0)
+        {
+            Index += WorldCount;
+        }
+        return Index;
+    }
+}
+
+AWorldManager::AWorldManager()
+{
+    PrimaryActorTick.bCanEverTick = false;
+    CurrentWorld = EWorldState::Light;
+}
+
+void AWorldManager::BeginPlay()
+{
+    Super::BeginPlay();
+
+    BroadcastWorldShift(CurrentWorld);
+}
+
+void AWorldManager::SetWorld(EWorldState NewWorld)
+{
+    if (CurrentWorld == NewWorld)
+    {
+        return;
+    }
+
+    CurrentWorld = NewWorld;
+    BroadcastWorldShift(CurrentWorld);
+}
+
+void AWorldManager::CycleWorld(int32 Direction)
+{
+    if (Direction == 0)
+    {
+        return;
+    }
+
+    Direction = FMath::Clamp(Direction, -1, 1);
+    const int32 WorldCount = GetWorldStateCount();
+    const int32 CurrentIndex = static_cast<int32>(CurrentWorld);
+    const int32 NextIndex = WrapWorldIndex(CurrentIndex + Direction);
+
+    SetWorld(static_cast<EWorldState>(NextIndex));
+}
+
+void AWorldManager::BroadcastWorldShift(EWorldState NewWorld)
+{
+    OnWorldShifted.Broadcast(NewWorld);
+
+    for (TActorIterator<AActor> It(GetWorld()); It; ++It)
+    {
+        AActor* Actor = *It;
+        TArray<UWorldShiftComponent*> Components;
+        Actor->GetComponents<UWorldShiftComponent>(Components);
+        for (UWorldShiftComponent* Component : Components)
+        {
+            if (Component)
+            {
+                Component->HandleWorldShift(NewWorld);
+            }
+        }
+    }
+}
+
+AWorldManager* AWorldManager::GetWorldManager(const UObject* WorldContextObject)
+{
+    if (!WorldContextObject)
+    {
+        return nullptr;
+    }
+
+    if (UWorld* World = GEngine ? GEngine->GetWorldFromContextObject(WorldContextObject, EGetWorldErrorMode::ReturnNull) : nullptr)
+    {
+        for (TActorIterator<AWorldManager> It(World); It; ++It)
+        {
+            return *It;
+        }
+    }
+
+    return nullptr;
+}

--- a/Source/GameJam/WorldManager.h
+++ b/Source/GameJam/WorldManager.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "WorldManager.generated.h"
+
+UENUM(BlueprintType)
+enum class EWorldState : uint8
+{
+    Light UMETA(DisplayName = "Light"),
+    Shadow UMETA(DisplayName = "Shadow"),
+    Dream UMETA(DisplayName = "Dream")
+};
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnWorldShiftedSignature, EWorldState, NewWorld);
+
+class UWorldShiftComponent;
+
+UCLASS(Blueprintable)
+class GAMEJAM_API AWorldManager : public AActor
+{
+    GENERATED_BODY()
+
+public:
+    AWorldManager();
+
+    virtual void BeginPlay() override;
+
+    UFUNCTION(BlueprintCallable, Category = "World")
+    EWorldState GetCurrentWorld() const { return CurrentWorld; }
+
+    UFUNCTION(BlueprintCallable, Category = "World")
+    void SetWorld(EWorldState NewWorld);
+
+    UFUNCTION(BlueprintCallable, Category = "World")
+    void CycleWorld(int32 Direction);
+
+    UPROPERTY(BlueprintAssignable, Category = "World")
+    FOnWorldShiftedSignature OnWorldShifted;
+
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "World")
+    EWorldState CurrentWorld;
+
+    UFUNCTION(BlueprintCallable, Category = "World")
+    static AWorldManager* GetWorldManager(const UObject* WorldContextObject);
+
+protected:
+    void BroadcastWorldShift(EWorldState NewWorld);
+};

--- a/Source/GameJam/WorldShiftComponent.cpp
+++ b/Source/GameJam/WorldShiftComponent.cpp
@@ -1,0 +1,53 @@
+#include "WorldShiftComponent.h"
+
+#include "GameFramework/Actor.h"
+#include "WorldManager.h"
+
+UWorldShiftComponent::UWorldShiftComponent()
+{
+    PrimaryComponentTick.bCanEverTick = false;
+}
+
+void UWorldShiftComponent::BeginPlay()
+{
+    Super::BeginPlay();
+
+    if (AWorldManager* Manager = AWorldManager::GetWorldManager(this))
+    {
+        Manager->OnWorldShifted.AddDynamic(this, &UWorldShiftComponent::HandleWorldShift);
+        HandleWorldShift(Manager->GetCurrentWorld());
+    }
+}
+
+void UWorldShiftComponent::HandleWorldShift(EWorldState NewWorld)
+{
+    bool bShouldBeVisible = false;
+    switch (NewWorld)
+    {
+    case EWorldState::Light:
+        bShouldBeVisible = bVisibleInLight;
+        break;
+    case EWorldState::Shadow:
+        bShouldBeVisible = bVisibleInShadow;
+        break;
+    case EWorldState::Dream:
+        bShouldBeVisible = bVisibleInDream;
+        break;
+    default:
+        break;
+    }
+
+    UpdateActorState(bShouldBeVisible);
+}
+
+void UWorldShiftComponent::UpdateActorState(bool bShouldBeActive) const
+{
+    if (AActor* Owner = GetOwner())
+    {
+        Owner->SetActorHiddenInGame(!bShouldBeActive);
+        if (bAffectsCollision)
+        {
+            Owner->SetActorEnableCollision(bShouldBeActive);
+        }
+    }
+}

--- a/Source/GameJam/WorldShiftComponent.h
+++ b/Source/GameJam/WorldShiftComponent.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+#include "WorldManager.h"
+#include "WorldShiftComponent.generated.h"
+
+UCLASS(ClassGroup=(World), Blueprintable, meta=(BlueprintSpawnableComponent))
+class GAMEJAM_API UWorldShiftComponent : public UActorComponent
+{
+    GENERATED_BODY()
+
+public:
+    UWorldShiftComponent();
+
+    virtual void BeginPlay() override;
+
+    UFUNCTION()
+    void HandleWorldShift(EWorldState NewWorld);
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "World")
+    bool bVisibleInLight = true;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "World")
+    bool bVisibleInShadow = false;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "World")
+    bool bVisibleInDream = false;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "World")
+    bool bAffectsCollision = true;
+
+protected:
+    void UpdateActorState(bool bShouldBeActive) const;
+};


### PR DESCRIPTION
## Summary
- add a World Manager actor with helper functions and multicast delegate for world changes
- create a World Shift component that responds to world shifts and updates actor visibility and collision
- bind the player character's Q/E keys to cycle through available worlds via the manager

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9334207ec832e8ac523e2fcf4f26b