### PR TITLE
Fix dynamic world shift delegate binding

### DIFF
--- a/Source/GameJam/WorldShiftComponent.cpp
+++ b/Source/GameJam/WorldShiftComponent.cpp
@@ -1,6 +1,7 @@
 #include "WorldShiftComponent.h"
 #include "WorldManager.h"
 #include "GameFramework/Actor.h"
+#include "Components/ActorComponent.h"
 #include "Components/PrimitiveComponent.h"
 
 UWorldShiftComponent::UWorldShiftComponent()
@@ -23,9 +24,9 @@ void UWorldShiftComponent::BeginPlay()
 
 void UWorldShiftComponent::EndPlay(const EEndPlayReason::Type EndPlayReason)
 {
-    if (CachedWorldManager.IsValid() && WorldShiftDelegateHandle.IsValid())
+    if (CachedWorldManager.IsValid())
     {
-        CachedWorldManager->OnWorldShifted.Remove(WorldShiftDelegateHandle);
+        CachedWorldManager->OnWorldShifted.RemoveDynamic(this, &UWorldShiftComponent::HandleWorldShift);
     }
 
     Super::EndPlay(EndPlayReason);
@@ -48,7 +49,7 @@ void UWorldShiftComponent::BindToWorldManager()
     if (AWorldManager* Manager = AWorldManager::Get(GetWorld()))
     {
         CachedWorldManager = Manager;
-        WorldShiftDelegateHandle = Manager->OnWorldShifted.AddUObject(this, &UWorldShiftComponent::HandleWorldShift);
+        Manager->OnWorldShifted.AddDynamic(this, &UWorldShiftComponent::HandleWorldShift);
     }
 }
 

--- a/Source/GameJam/WorldShiftComponent.h
+++ b/Source/GameJam/WorldShiftComponent.h
@@ -31,5 +31,4 @@ private:
     void HandleWorldShift(EWorldState NewWorld);
 
     TWeakObjectPtr<AWorldManager> CachedWorldManager;
-    FDelegateHandle WorldShiftDelegateHandle;
 };


### PR DESCRIPTION
## Summary
- include the actor component header so GetComponentsByClass resolves
- switch the world shift bindings to AddDynamic/RemoveDynamic for the dynamic multicast delegate
- drop the unused delegate handle member now that dynamic binding is used

## Testing
- not run (Unreal project)

------
https://chatgpt.com/codex/tasks/task_e_68d939481a38832e91c4d7f820e5d0aa