### PR TITLE
Rename Dream world state to Chaos

### DIFF
--- a/Source/GameJam/WorldManager.cpp
+++ b/Source/GameJam/WorldManager.cpp
@@ -106,8 +106,8 @@ EWorldState AWorldManager::GetNextWorld(EWorldState InWorld)
     case EWorldState::Light:
         return EWorldState::Shadow;
     case EWorldState::Shadow:
-        return EWorldState::Dream;
-    case EWorldState::Dream:
+        return EWorldState::Chaos;
+    case EWorldState::Chaos:
     default:
         return EWorldState::Light;
     }
@@ -118,10 +118,10 @@ EWorldState AWorldManager::GetPreviousWorld(EWorldState InWorld)
     switch (InWorld)
     {
     case EWorldState::Light:
-        return EWorldState::Dream;
+        return EWorldState::Chaos;
     case EWorldState::Shadow:
         return EWorldState::Light;
-    case EWorldState::Dream:
+    case EWorldState::Chaos:
     default:
         return EWorldState::Shadow;
     }

--- a/Source/GameJam/WorldShiftTypes.h
+++ b/Source/GameJam/WorldShiftTypes.h
@@ -8,7 +8,7 @@ enum class EWorldState : uint8
 {
     Light UMETA(DisplayName = "Light"),
     Shadow UMETA(DisplayName = "Shadow"),
-    Dream UMETA(DisplayName = "Dream")
+    Chaos UMETA(DisplayName = "Chaos")
 };
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnWorldShifted, EWorldState, NewWorld);


### PR DESCRIPTION
## Summary
- rename the EWorldState enum entry from Dream to Chaos and update its display name
- adjust world cycling logic to use the new Chaos state

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d94b9e3b80832e819e887a386e8a6a