### PR TITLE
Stop binding inputs from world manager

### DIFF
--- a/Source/GameJam/WorldManager.cpp
+++ b/Source/GameJam/WorldManager.cpp
@@ -1,8 +1,11 @@
 #include "WorldManager.h"
-#include "GameFramework/PlayerController.h"
+
+#include "AudioDevice.h"
+#include "Components/PostProcessComponent.h"
+#include "Components/SceneComponent.h"
 #include "Engine/World.h"
 #include "EngineUtils.h"
-#include "InputCoreTypes.h"
+#include "Sound/SoundMix.h"
 
 TWeakObjectPtr<AWorldManager> AWorldManager::ActiveWorldManager = nullptr;
 
@@ -10,8 +13,16 @@ AWorldManager::AWorldManager()
 {
     PrimaryActorTick.bCanEverTick = false;
 
+    RootComponent = CreateDefaultSubobject<USceneComponent>(TEXT("RootComponent"));
+
+    PostProcessComponent = CreateDefaultSubobject<UPostProcessComponent>(TEXT("PostProcessComponent"));
+    PostProcessComponent->SetupAttachment(RootComponent);
+    PostProcessComponent->bUnbound = true;
+    PostProcessComponent->BlendWeight = 1.0f;
+
     StartingWorld = EWorldState::Light;
     CurrentWorld = StartingWorld;
+    SoundMixFadeTime = 0.5f;
 }
 
 AWorldManager* AWorldManager::Get(UWorld* World)
@@ -43,10 +54,16 @@ void AWorldManager::BeginPlay()
     Super::BeginPlay();
 
     ActiveWorldManager = this;
+
+    if (PostProcessComponent)
+    {
+        DefaultPostProcessSettings = PostProcessComponent->Settings;
+    }
+
     CurrentWorld = StartingWorld;
 
-    InitializeInput();
-    BroadcastWorldShift();
+    ApplyWorldFeedback(CurrentWorld);
+    OnWorldShifted.Broadcast(CurrentWorld);
 }
 
 void AWorldManager::EndPlay(const EEndPlayReason::Type EndPlayReason)
@@ -56,21 +73,22 @@ void AWorldManager::EndPlay(const EEndPlayReason::Type EndPlayReason)
         ActiveWorldManager = nullptr;
     }
 
-    Super::EndPlay(EndPlayReason);
-}
-
-void AWorldManager::InitializeInput()
-{
-    if (APlayerController* PC = GetWorld()->GetFirstPlayerController())
+    if (FAudioDevice* AudioDevice = GetWorld() ? GetWorld()->GetAudioDeviceRaw() : nullptr)
     {
-        EnableInput(PC);
-
-        if (InputComponent)
+        if (ActiveSoundMix.IsValid())
         {
-            InputComponent->BindKey(EKeys::E, IE_Pressed, this, &AWorldManager::ShiftToNextWorld);
-            InputComponent->BindKey(EKeys::Q, IE_Pressed, this, &AWorldManager::ShiftToPreviousWorld);
+            AudioDevice->PopSoundMixModifier(ActiveSoundMix.Get(), SoundMixFadeTime);
+        }
+
+        if (DefaultSoundMix)
+        {
+            AudioDevice->SetBaseSoundMix(DefaultSoundMix.Get());
         }
     }
+
+    ActiveSoundMix.Reset();
+
+    Super::EndPlay(EndPlayReason);
 }
 
 void AWorldManager::SetWorld(EWorldState NewWorld)
@@ -81,22 +99,99 @@ void AWorldManager::SetWorld(EWorldState NewWorld)
     }
 
     CurrentWorld = NewWorld;
-    BroadcastWorldShift();
+
+    ApplyWorldFeedback(CurrentWorld);
+    OnWorldShifted.Broadcast(CurrentWorld);
+}
+
+void AWorldManager::CycleWorld(int32 Direction)
+{
+    if (Direction == 0)
+    {
+        return;
+    }
+
+    const int32 Steps = FMath::Abs(Direction);
+    EWorldState TargetWorld = CurrentWorld;
+    for (int32 StepIndex = 0; StepIndex < Steps; ++StepIndex)
+    {
+        TargetWorld = (Direction > 0) ? GetNextWorld(TargetWorld) : GetPreviousWorld(TargetWorld);
+    }
+
+    SetWorld(TargetWorld);
 }
 
 void AWorldManager::ShiftToNextWorld()
 {
-    SetWorld(GetNextWorld(CurrentWorld));
+    CycleWorld(1);
 }
 
 void AWorldManager::ShiftToPreviousWorld()
 {
-    SetWorld(GetPreviousWorld(CurrentWorld));
+    CycleWorld(-1);
 }
 
-void AWorldManager::BroadcastWorldShift()
+void AWorldManager::ApplyWorldFeedback(EWorldState NewWorld)
 {
-    OnWorldShifted.Broadcast(CurrentWorld);
+    ApplyPostProcessForWorld(NewWorld);
+    ApplyAudioForWorld(NewWorld);
+}
+
+void AWorldManager::ApplyPostProcessForWorld(EWorldState NewWorld)
+{
+    if (!PostProcessComponent)
+    {
+        return;
+    }
+
+    if (const FPostProcessSettings* Settings = WorldPostProcessSettings.Find(NewWorld))
+    {
+        PostProcessComponent->Settings = *Settings;
+    }
+    else
+    {
+        PostProcessComponent->Settings = DefaultPostProcessSettings;
+    }
+
+    PostProcessComponent->BlendWeight = 1.0f;
+}
+
+void AWorldManager::ApplyAudioForWorld(EWorldState NewWorld)
+{
+    USoundMix* DesiredMix = nullptr;
+    if (TObjectPtr<USoundMix>* const MixPtr = WorldSoundMixes.Find(NewWorld))
+    {
+        DesiredMix = MixPtr->Get();
+    }
+
+    if (!DesiredMix)
+    {
+        DesiredMix = DefaultSoundMix.Get();
+    }
+
+    if (DesiredMix == ActiveSoundMix.Get())
+    {
+        return;
+    }
+
+    if (FAudioDevice* AudioDevice = GetWorld() ? GetWorld()->GetAudioDeviceRaw() : nullptr)
+    {
+        if (ActiveSoundMix.IsValid())
+        {
+            AudioDevice->PopSoundMixModifier(ActiveSoundMix.Get(), SoundMixFadeTime);
+        }
+
+        if (DesiredMix)
+        {
+            AudioDevice->PushSoundMixModifier(DesiredMix, true, true, SoundMixFadeTime);
+            AudioDevice->SetBaseSoundMix(DesiredMix);
+            ActiveSoundMix = DesiredMix;
+        }
+        else
+        {
+            ActiveSoundMix.Reset();
+        }
+    }
 }
 
 EWorldState AWorldManager::GetNextWorld(EWorldState InWorld)

--- a/Source/GameJam/WorldManager.h
+++ b/Source/GameJam/WorldManager.h
@@ -1,10 +1,28 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "Engine/PostProcessVolume.h"
 #include "GameFramework/Actor.h"
-#include "WorldShiftTypes.h"
 #include "WorldManager.generated.h"
 
+class UPostProcessComponent;
+class USoundMix;
+
+/** Enum describing the three available world states. */
+UENUM(BlueprintType)
+enum class EWorldState : uint8
+{
+    Light UMETA(DisplayName = "Light"),
+    Shadow UMETA(DisplayName = "Shadow"),
+    Dream UMETA(DisplayName = "Dream")
+};
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnWorldShifted, EWorldState, NewWorld);
+
+/**
+ * Central manager responsible for tracking the active world and applying
+ * audiovisual feedback when the world changes.
+ */
 UCLASS(BlueprintType)
 class GAMEJAM_API AWorldManager : public AActor
 {
@@ -13,20 +31,30 @@ class GAMEJAM_API AWorldManager : public AActor
 public:
     AWorldManager();
 
+    /** Returns the globally accessible world manager for the provided world. */
     static AWorldManager* Get(UWorld* World);
 
-    UFUNCTION(BlueprintCallable, Category = "World Shift")
-    void SetWorld(EWorldState NewWorld);
-
-    UFUNCTION(BlueprintCallable, Category = "World Shift")
-    void ShiftToNextWorld();
-
-    UFUNCTION(BlueprintCallable, Category = "World Shift")
-    void ShiftToPreviousWorld();
-
+    /** Returns the currently active world. */
     UFUNCTION(BlueprintPure, Category = "World Shift")
     EWorldState GetCurrentWorld() const { return CurrentWorld; }
 
+    /** Sets the current world to the supplied value. */
+    UFUNCTION(BlueprintCallable, Category = "World Shift")
+    void SetWorld(EWorldState NewWorld);
+
+    /** Cycles forward or backward depending on the provided direction. */
+    UFUNCTION(BlueprintCallable, Category = "World Shift")
+    void CycleWorld(int32 Direction);
+
+    /** Convenience wrapper that cycles forward (Light → Shadow → Dream). */
+    UFUNCTION(BlueprintCallable, Category = "World Shift")
+    void ShiftToNextWorld();
+
+    /** Convenience wrapper that cycles backward (Dream → Shadow → Light). */
+    UFUNCTION(BlueprintCallable, Category = "World Shift")
+    void ShiftToPreviousWorld();
+
+    /** Broadcast when the world changes. */
     UPROPERTY(BlueprintAssignable, Category = "World Shift")
     FOnWorldShifted OnWorldShifted;
 
@@ -34,18 +62,69 @@ protected:
     virtual void BeginPlay() override;
     virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
 
-    void InitializeInput();
+    /** Applies all audiovisual feedback related to the supplied world. */
+    void ApplyWorldFeedback(EWorldState NewWorld);
+
+    /** Applies post-process settings for the supplied world. */
+    void ApplyPostProcessForWorld(EWorldState NewWorld);
+
+    /** Applies audio snapshot for the supplied world. */
+    void ApplyAudioForWorld(EWorldState NewWorld);
 
 private:
     static TWeakObjectPtr<AWorldManager> ActiveWorldManager;
 
-    void BroadcastWorldShift();
-
+    /** Ordered helper used for cycling between worlds. */
     static EWorldState GetNextWorld(EWorldState InWorld);
     static EWorldState GetPreviousWorld(EWorldState InWorld);
 
-    UPROPERTY(EditAnywhere, Category = "World Shift")
+    /** Component used to apply camera wide post-process effects. */
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "World Shift|Visual", meta = (AllowPrivateAccess = "true"))
+    TObjectPtr<UPostProcessComponent> PostProcessComponent;
+
+    /** Configurable post-process settings per world. */
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "World Shift|Visual", meta = (AllowPrivateAccess = "true"))
+    TMap<EWorldState, FPostProcessSettings> WorldPostProcessSettings;
+
+    /** Copy of the initial post process settings used as fallback. */
+    UPROPERTY(VisibleInstanceOnly, Category = "World Shift|Visual", meta = (AllowPrivateAccess = "true"))
+    FPostProcessSettings DefaultPostProcessSettings;
+
+    /** Optional default mix used when no world specific mix is set. */
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "World Shift|Audio", meta = (AllowPrivateAccess = "true"))
+    TObjectPtr<USoundMix> DefaultSoundMix;
+
+    /** Per-world sound mixes to fade to. */
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "World Shift|Audio", meta = (AllowPrivateAccess = "true"))
+    TMap<EWorldState, TObjectPtr<USoundMix>> WorldSoundMixes;
+
+    /** Seconds to fade between audio mixes. */
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "World Shift|Audio", meta = (AllowPrivateAccess = "true"))
+    float SoundMixFadeTime;
+
+    /** Starting world configured in the editor. */
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "World Shift", meta = (AllowPrivateAccess = "true"))
     EWorldState StartingWorld;
 
+    /** Cached pointer to the currently active sound mix. */
+    TWeakObjectPtr<USoundMix> ActiveSoundMix;
+
+    /** Currently active world. */
+    UPROPERTY(VisibleInstanceOnly, BlueprintReadOnly, Category = "World Shift", meta = (AllowPrivateAccess = "true"))
     EWorldState CurrentWorld;
 };
+
+/**
+ * Example of routing an input action from a character:
+ *
+ * void AGameJamCharacter::CycleWorld(const FInputActionValue& Value)
+ * {
+ *     if (const float AxisValue = Value.Get<float>(); !FMath::IsNearlyZero(AxisValue))
+ *     {
+ *         if (AWorldManager* Manager = AWorldManager::Get(GetWorld()))
+ *         {
+ *             Manager->CycleWorld(AxisValue > 0.0f ? 1 : -1);
+ *         }
+ *     }
+ * }
+ */

--- a/Source/GameJam/WorldShiftTypes.h
+++ b/Source/GameJam/WorldShiftTypes.h
@@ -1,14 +1,3 @@
 #pragma once
 
-#include "CoreMinimal.h"
-#include "WorldShiftTypes.generated.h"
-
-UENUM(BlueprintType)
-enum class EWorldState : uint8
-{
-    Light UMETA(DisplayName = "Light"),
-    Shadow UMETA(DisplayName = "Shadow"),
-    Dream UMETA(DisplayName = "Dream")
-};
-
-DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnWorldShifted, EWorldState, NewWorld);
+#include "WorldManager.h"


### PR DESCRIPTION
## Summary
- stop the world manager from enabling its own input component and binding Q/E directly
- rely on the existing GameJamCharacter input action to call CycleWorld instead, updating the usage example accordingly

## Testing
- not run (engine build not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68d948bd53d0832eb93b60ea4c4477b0