### PR TITLE
Refactor world audio to submix-driven music

### DIFF
--- a/Source/GameJam/WorldManager.cpp
+++ b/Source/GameJam/WorldManager.cpp
@@ -1,11 +1,13 @@
 #include "WorldManager.h"
 
-#include "AudioDevice.h"
 #include "Components/PostProcessComponent.h"
 #include "Components/SceneComponent.h"
 #include "Engine/World.h"
 #include "EngineUtils.h"
-#include "Sound/SoundMix.h"
+#include "Kismet/GameplayStatics.h"
+#include "Sound/SoundBase.h"
+#include "Sound/SoundSubmix.h"
+#include "Components/AudioComponent.h"
 
 TWeakObjectPtr<AWorldManager> AWorldManager::ActiveWorldManager = nullptr;
 
@@ -22,7 +24,7 @@ AWorldManager::AWorldManager()
 
     StartingWorld = EWorldState::Light;
     CurrentWorld = StartingWorld;
-    SoundMixFadeTime = 0.5f;
+    MusicFadeTime = 0.5f;
 }
 
 AWorldManager* AWorldManager::Get(UWorld* World)
@@ -73,20 +75,18 @@ void AWorldManager::EndPlay(const EEndPlayReason::Type EndPlayReason)
         ActiveWorldManager = nullptr;
     }
 
-    if (FAudioDevice* AudioDevice = GetWorld() ? GetWorld()->GetAudioDeviceRaw() : nullptr)
+    if (ActiveMusicComponent.IsValid())
     {
-        if (ActiveSoundMix.IsValid())
+        if (MusicFadeTime > 0.0f)
         {
-            AudioDevice->PopSoundMixModifier(ActiveSoundMix.Get(), SoundMixFadeTime);
+            ActiveMusicComponent->FadeOut(MusicFadeTime, 0.0f);
         }
-
-        if (DefaultSoundMix)
+        else
         {
-            AudioDevice->SetBaseSoundMix(DefaultSoundMix.Get());
+            ActiveMusicComponent->Stop();
         }
+        ActiveMusicComponent.Reset();
     }
-
-    ActiveSoundMix.Reset();
 
     Super::EndPlay(EndPlayReason);
 }
@@ -95,10 +95,8 @@ void AWorldManager::SetWorld(EWorldState NewWorld)
 {
     if (CurrentWorld == NewWorld)
     {
-		UE_LOG(LogTemp, Warning, TEXT("Already in world: %d"), (int32)CurrentWorld);
         return;
     }
-	UE_LOG(LogTemp, Warning, TEXT("Shifting world from %d to %d"), (int32)CurrentWorld, (int32)NewWorld);
     CurrentWorld = NewWorld;
 
     ApplyWorldFeedback(CurrentWorld);
@@ -159,42 +157,57 @@ void AWorldManager::ApplyPostProcessForWorld(EWorldState NewWorld)
 
 void AWorldManager::ApplyAudioForWorld(EWorldState NewWorld)
 {
-    USoundMix* DesiredMix = nullptr;
-    if (TObjectPtr<USoundMix>* const MixPtr = WorldSoundMixes.Find(NewWorld))
+    if (ActiveMusicComponent.IsValid())
     {
-        DesiredMix = MixPtr->Get();
+        if (MusicFadeTime > 0.0f)
+        {
+            ActiveMusicComponent->FadeOut(MusicFadeTime, 0.0f);
+        }
+        else
+        {
+            ActiveMusicComponent->Stop();
+        }
+        ActiveMusicComponent.Reset();
     }
 
-    if (!DesiredMix)
-    {
-        DesiredMix = DefaultSoundMix.Get();
-    }
-
-    if (DesiredMix == ActiveSoundMix.Get())
+    const TObjectPtr<USoundBase>* SongPtr = WorldSongs.Find(NewWorld);
+    USoundBase* WorldSong = SongPtr ? SongPtr->Get() : nullptr;
+    if (!WorldSong)
     {
         return;
     }
 
-    if (FAudioDevice* AudioDevice = GetWorld() ? GetWorld()->GetAudioDeviceRaw() : nullptr)
+    UAudioComponent* const NewMusicComponent = UGameplayStatics::SpawnSound2D(
+        this,
+        WorldSong,
+        0.0f,
+        1.0f,
+        0.0f,
+        nullptr,
+        false,
+        true);
+    if (!NewMusicComponent)
     {
-        if (ActiveSoundMix.IsValid())
-        {
-            AudioDevice->PopSoundMixModifier(ActiveSoundMix.Get(), SoundMixFadeTime);
-        }
-	UE_LOG(LogTemp, Warning, TEXT("Shifting to previous world from: %d"), (int32)CurrentWorld);
-    SetWorld(GetPreviousWorld(CurrentWorld));
-}
+        return;
+    }
 
-        if (DesiredMix)
+    if (const TObjectPtr<USoundSubmix>* SubmixPtr = WorldSubmixes.Find(NewWorld))
+    {
+        if (USoundSubmix* Submix = SubmixPtr->Get())
         {
-            AudioDevice->PushSoundMixModifier(DesiredMix, true, true, SoundMixFadeTime);
-            AudioDevice->SetBaseSoundMix(DesiredMix);
-            ActiveSoundMix = DesiredMix;
+            NewMusicComponent->SoundSubmixOverride = Submix;
         }
-        else
-        {
-            ActiveSoundMix.Reset();
-        }
+    }
+
+    ActiveMusicComponent = NewMusicComponent;
+
+    if (MusicFadeTime > 0.0f)
+    {
+        NewMusicComponent->FadeIn(MusicFadeTime, 1.0f);
+    }
+    else
+    {
+        NewMusicComponent->SetVolumeMultiplier(1.0f);
     }
 }
 
@@ -205,8 +218,8 @@ EWorldState AWorldManager::GetNextWorld(EWorldState InWorld)
     case EWorldState::Light:
         return EWorldState::Shadow;
     case EWorldState::Shadow:
-        return EWorldState::Chaos;
-    case EWorldState::Chaos:
+        return EWorldState::Dream;
+    case EWorldState::Dream:
     default:
         return EWorldState::Light;
     }
@@ -217,10 +230,10 @@ EWorldState AWorldManager::GetPreviousWorld(EWorldState InWorld)
     switch (InWorld)
     {
     case EWorldState::Light:
-        return EWorldState::Chaos;
+        return EWorldState::Dream;
     case EWorldState::Shadow:
         return EWorldState::Light;
-    case EWorldState::Chaos:
+    case EWorldState::Dream:
     default:
         return EWorldState::Shadow;
     }

--- a/Source/GameJam/WorldManager.h
+++ b/Source/GameJam/WorldManager.h
@@ -5,8 +5,10 @@
 #include "GameFramework/Actor.h"
 #include "WorldManager.generated.h"
 
+class UAudioComponent;
 class UPostProcessComponent;
-class USoundMix;
+class USoundBase;
+class USoundSubmix;
 
 /** Enum describing the three available world states. */
 UENUM(BlueprintType)
@@ -90,24 +92,24 @@ private:
     UPROPERTY(VisibleInstanceOnly, Category = "World Shift|Visual", meta = (AllowPrivateAccess = "true"))
     FPostProcessSettings DefaultPostProcessSettings;
 
-    /** Optional default mix used when no world specific mix is set. */
+    /** Per-world output submix routing. */
     UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "World Shift|Audio", meta = (AllowPrivateAccess = "true"))
-    TObjectPtr<USoundMix> DefaultSoundMix;
+    TMap<EWorldState, TObjectPtr<USoundSubmix>> WorldSubmixes;
 
-    /** Per-world sound mixes to fade to. */
+    /** Per-world music assets. */
     UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "World Shift|Audio", meta = (AllowPrivateAccess = "true"))
-    TMap<EWorldState, TObjectPtr<USoundMix>> WorldSoundMixes;
+    TMap<EWorldState, TObjectPtr<USoundBase>> WorldSongs;
 
-    /** Seconds to fade between audio mixes. */
+    /** Seconds to fade between world songs. */
     UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "World Shift|Audio", meta = (AllowPrivateAccess = "true"))
-    float SoundMixFadeTime;
+    float MusicFadeTime;
 
     /** Starting world configured in the editor. */
     UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "World Shift", meta = (AllowPrivateAccess = "true"))
     EWorldState StartingWorld;
 
-    /** Cached pointer to the currently active sound mix. */
-    TWeakObjectPtr<USoundMix> ActiveSoundMix;
+    /** Currently active music component. */
+    TWeakObjectPtr<UAudioComponent> ActiveMusicComponent;
 
     /** Currently active world. */
     UPROPERTY(VisibleInstanceOnly, BlueprintReadOnly, Category = "World Shift", meta = (AllowPrivateAccess = "true"))


### PR DESCRIPTION
## Summary
- replace the world sound mix workflow with per-world song and submix assignments
- play and fade world music through a tracked audio component that applies the configured submix override
- tidy world cycling helpers to use the defined Dream world state

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d99d68d65c832e90b250c3a7d9e2a0