### PR TITLE
Refactor AWorldManager audio handling to use submix workflow

### DIFF
--- a/Source/GameJam/WorldManager.cpp
+++ b/Source/GameJam/WorldManager.cpp
@@ -79,15 +79,13 @@ void AWorldManager::EndPlay(const EEndPlayReason::Type EndPlayReason)
     {
         if (MusicFadeTime > 0.0f)
         {
-
             ActiveMusicComponent->FadeOut(MusicFadeTime, 0.0f);
-            AudioDevice->PopSoundMixModifier(ActiveSoundMix.Get());
-
         }
         else
         {
             ActiveMusicComponent->Stop();
         }
+
         ActiveMusicComponent.Reset();
     }
 
@@ -170,6 +168,7 @@ void AWorldManager::ApplyAudioForWorld(EWorldState NewWorld)
         {
             ActiveMusicComponent->Stop();
         }
+
         ActiveMusicComponent.Reset();
     }
 
@@ -180,7 +179,7 @@ void AWorldManager::ApplyAudioForWorld(EWorldState NewWorld)
         return;
     }
 
-    UAudioComponent* const NewMusicComponent = UGameplayStatics::SpawnSound2D(
+    UAudioComponent* NewMusicComponent = UGameplayStatics::SpawnSound2D(
         this,
         WorldSong,
         0.0f,
@@ -195,11 +194,6 @@ void AWorldManager::ApplyAudioForWorld(EWorldState NewWorld)
     }
 
     if (const TObjectPtr<USoundSubmix>* SubmixPtr = WorldSubmixes.Find(NewWorld))
-
-	FAudioDevice* AudioDevice = nullptr;    
-    AudioDevice = GetWorld() ? GetWorld()->GetAudioDeviceRaw() : nullptr;
-    if (AudioDevice)
-
     {
         if (USoundSubmix* Submix = SubmixPtr->Get())
         {
@@ -216,24 +210,8 @@ void AWorldManager::ApplyAudioForWorld(EWorldState NewWorld)
     else
     {
         NewMusicComponent->SetVolumeMultiplier(1.0f);
-            AudioDevice->PopSoundMixModifier(ActiveSoundMix.Get());
-        }
-	UE_LOG(LogTemp, Warning, TEXT("Shifting to previous world from: %d"), (int32)CurrentWorld);
-    SetWorld(GetPreviousWorld(CurrentWorld));
     }
-
-        if (DesiredMix)
-        {
-            AudioDevice->PushSoundMixModifier(DesiredMix, true, true);
-            AudioDevice->SetBaseSoundMix(DesiredMix);
-            ActiveSoundMix = DesiredMix;
-        }
-        else
-        {
-            ActiveSoundMix.Reset();
-        }
-    }
-
+}
 
 EWorldState AWorldManager::GetNextWorld(EWorldState InWorld)
 {


### PR DESCRIPTION
## Summary
- remove the legacy SoundMix and audio device logic from AWorldManager
- fade between world songs using SpawnSound2D and per-world submix overrides

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da123e39c4832eacf7044fac5aaf28