### PR TITLE
Add configurable world state behavior for shift platforms

### DIFF
--- a/Source/GameJam/ShiftPlatform.cpp
+++ b/Source/GameJam/ShiftPlatform.cpp
@@ -1,11 +1,217 @@
 #include "ShiftPlatform.h"
+
 #include "Components/StaticMeshComponent.h"
+#include "Engine/World.h"
+#include "Materials/MaterialInterface.h"
+#include "TimerManager.h"
+#include "WorldManager.h"
 #include "WorldShiftComponent.h"
 
 AShiftPlatform::AShiftPlatform()
 {
+    PrimaryActorTick.bCanEverTick = false;
+
     PlatformMesh = CreateDefaultSubobject<UStaticMeshComponent>(TEXT("PlatformMesh"));
     RootComponent = PlatformMesh;
 
     WorldShiftComponent = CreateDefaultSubobject<UWorldShiftComponent>(TEXT("WorldShiftComponent"));
+
+    WorldBehaviors.Add(EWorldState::Light, EPlatformState::Solid);
+    WorldBehaviors.Add(EWorldState::Shadow, EPlatformState::Ghost);
+    WorldBehaviors.Add(EWorldState::Chaos, EPlatformState::Solid);
+
+    CurrentWorld = EWorldState::Light;
+    bTimedSolidCurrentlySolid = false;
 }
+
+void AShiftPlatform::BeginPlay()
+{
+    Super::BeginPlay();
+
+    if (AWorldManager* Manager = AWorldManager::Get(GetWorld()))
+    {
+        CachedWorldManager = Manager;
+        Manager->OnWorldShifted.AddDynamic(this, &AShiftPlatform::HandleWorldShift);
+        HandleWorldShift(Manager->GetCurrentWorld());
+    }
+    else
+    {
+        HandleWorldShift(CurrentWorld);
+    }
+}
+
+void AShiftPlatform::EndPlay(const EEndPlayReason::Type EndPlayReason)
+{
+    StopTimedSolidCycle();
+
+    if (CachedWorldManager.IsValid())
+    {
+        CachedWorldManager->OnWorldShifted.RemoveDynamic(this, &AShiftPlatform::HandleWorldShift);
+        CachedWorldManager.Reset();
+    }
+
+    Super::EndPlay(EndPlayReason);
+}
+
+void AShiftPlatform::HandleWorldShift(EWorldState NewWorld)
+{
+    CurrentWorld = NewWorld;
+    const EPlatformState Behavior = GetBehaviorForWorld(NewWorld);
+
+    ApplyPlatformState(Behavior, NewWorld);
+}
+
+void AShiftPlatform::ApplyPlatformState(EPlatformState NewState, EWorldState WorldContext)
+{
+    switch (NewState)
+    {
+    case EPlatformState::Solid:
+        StopTimedSolidCycle();
+        ApplySolidState();
+        break;
+    case EPlatformState::Ghost:
+        StopTimedSolidCycle();
+        ApplyGhostState(WorldContext);
+        break;
+    case EPlatformState::Hidden:
+        StopTimedSolidCycle();
+        ApplyHiddenState();
+        break;
+    case EPlatformState::TimedSolid:
+        if (WorldContext == EWorldState::Chaos)
+        {
+            StartTimedSolidCycle();
+        }
+        else
+        {
+            StopTimedSolidCycle();
+            ApplySolidState();
+        }
+        break;
+    default:
+        StopTimedSolidCycle();
+        ApplySolidState();
+        break;
+    }
+}
+
+void AShiftPlatform::ApplySolidState()
+{
+    if (!PlatformMesh)
+    {
+        return;
+    }
+
+    PlatformMesh->SetHiddenInGame(false);
+    PlatformMesh->SetVisibility(true, true);
+    PlatformMesh->SetCollisionEnabled(ECollisionEnabled::QueryAndPhysics);
+
+    if (SolidMaterial)
+    {
+        ApplyMaterial(SolidMaterial.Get());
+    }
+}
+
+void AShiftPlatform::ApplyGhostState(EWorldState WorldContext)
+{
+    if (!PlatformMesh)
+    {
+        return;
+    }
+
+    PlatformMesh->SetHiddenInGame(false);
+    PlatformMesh->SetVisibility(true, true);
+    PlatformMesh->SetCollisionEnabled(ECollisionEnabled::NoCollision);
+
+    if (const TObjectPtr<UMaterialInterface>* MaterialPtr = GhostMaterials.Find(WorldContext))
+    {
+        if (UMaterialInterface* Material = MaterialPtr->Get())
+        {
+            ApplyMaterial(Material);
+        }
+    }
+}
+
+void AShiftPlatform::ApplyHiddenState()
+{
+    if (!PlatformMesh)
+    {
+        return;
+    }
+
+    PlatformMesh->SetCollisionEnabled(ECollisionEnabled::NoCollision);
+    PlatformMesh->SetHiddenInGame(true);
+    PlatformMesh->SetVisibility(false, true);
+}
+
+void AShiftPlatform::StartTimedSolidCycle()
+{
+    StopTimedSolidCycle();
+
+    bTimedSolidCurrentlySolid = false;
+
+    if (UWorld* World = GetWorld())
+    {
+        World->GetTimerManager().SetTimer(TimedSolidTimerHandle, this, &AShiftPlatform::HandleTimedSolidToggle, 2.0f, true, 2.0f);
+        HandleTimedSolidToggle();
+    }
+    else
+    {
+        ApplySolidState();
+    }
+}
+
+void AShiftPlatform::StopTimedSolidCycle()
+{
+    if (UWorld* World = GetWorld())
+    {
+        World->GetTimerManager().ClearTimer(TimedSolidTimerHandle);
+    }
+
+    bTimedSolidCurrentlySolid = false;
+}
+
+void AShiftPlatform::HandleTimedSolidToggle()
+{
+    bTimedSolidCurrentlySolid = !bTimedSolidCurrentlySolid;
+
+    if (bTimedSolidCurrentlySolid)
+    {
+        ApplySolidState();
+    }
+    else
+    {
+        ApplyGhostState(CurrentWorld);
+    }
+}
+
+EPlatformState AShiftPlatform::GetBehaviorForWorld(EWorldState WorldContext) const
+{
+    if (const EPlatformState* FoundState = WorldBehaviors.Find(WorldContext))
+    {
+        return *FoundState;
+    }
+
+    return EPlatformState::Solid;
+}
+
+void AShiftPlatform::ApplyMaterial(UMaterialInterface* Material)
+{
+    if (!PlatformMesh || !Material)
+    {
+        return;
+    }
+
+    const int32 MaterialCount = PlatformMesh->GetNumMaterials();
+    for (int32 MaterialIndex = 0; MaterialIndex < MaterialCount; ++MaterialIndex)
+    {
+        PlatformMesh->SetMaterial(MaterialIndex, Material);
+    }
+}
+
+/*
+Example editor setup:
+- WorldBehaviors → Light: Solid, Shadow: Ghost, Chaos: TimedSolid.
+- SolidMaterial → assign the opaque platform material.
+- GhostMaterials → Light: light-tinted ghost, Shadow: dark-tinted ghost, Chaos: vibrant ghost hue.
+*/

--- a/Source/GameJam/ShiftPlatform.h
+++ b/Source/GameJam/ShiftPlatform.h
@@ -2,10 +2,23 @@
 
 #include "CoreMinimal.h"
 #include "GameFramework/Actor.h"
+#include "WorldShiftTypes.h"
 #include "ShiftPlatform.generated.h"
 
 class UStaticMeshComponent;
 class UWorldShiftComponent;
+class UMaterialInterface;
+class AWorldManager;
+struct FTimerHandle;
+
+UENUM(BlueprintType)
+enum class EPlatformState : uint8
+{
+    Solid UMETA(DisplayName = "Solid"),
+    Ghost UMETA(DisplayName = "Ghost"),
+    Hidden UMETA(DisplayName = "Hidden"),
+    TimedSolid UMETA(DisplayName = "Timed Solid")
+};
 
 UCLASS()
 class GAMEJAM_API AShiftPlatform : public AActor
@@ -16,9 +29,44 @@ public:
     AShiftPlatform();
 
 protected:
+    virtual void BeginPlay() override;
+    virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
+
     UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Components")
     TObjectPtr<UStaticMeshComponent> PlatformMesh;
 
     UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "World Shift")
     TObjectPtr<UWorldShiftComponent> WorldShiftComponent;
+
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "World Shift")
+    TMap<EWorldState, EPlatformState> WorldBehaviors;
+
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "World Shift|Materials")
+    TObjectPtr<UMaterialInterface> SolidMaterial;
+
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "World Shift|Materials")
+    TMap<EWorldState, TObjectPtr<UMaterialInterface>> GhostMaterials;
+
+private:
+    UFUNCTION()
+    void HandleWorldShift(EWorldState NewWorld);
+
+    void ApplyPlatformState(EPlatformState NewState, EWorldState WorldContext);
+    void ApplySolidState();
+    void ApplyGhostState(EWorldState WorldContext);
+    void ApplyHiddenState();
+
+    void StartTimedSolidCycle();
+    void StopTimedSolidCycle();
+    void HandleTimedSolidToggle();
+
+    EPlatformState GetBehaviorForWorld(EWorldState WorldContext) const;
+    void ApplyMaterial(UMaterialInterface* Material);
+
+    TWeakObjectPtr<AWorldManager> CachedWorldManager;
+
+    FTimerHandle TimedSolidTimerHandle;
+
+    EWorldState CurrentWorld;
+    bool bTimedSolidCurrentlySolid;
 };


### PR DESCRIPTION
## Summary
- implement platform state enum and expose per-world behavior mapping for shift platforms
- respond to world change broadcasts, including chaos timed-solid flicker, and update visibility/collision/materials
- expose solid and per-world ghost materials with an example editor setup for designers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68daedc20eb4832e8aabc7592988bf93