### PR TITLE
Add prefab configuration support to shift platforms

### DIFF
--- a/Source/GameJam/ShiftPlatform.h
+++ b/Source/GameJam/ShiftPlatform.h
@@ -20,6 +20,21 @@ enum class EPlatformState : uint8
     TimedSolid UMETA(DisplayName = "Timed Solid")
 };
 
+UENUM(BlueprintType)
+enum class EPlatformPrefabType : uint8
+{
+    LightBridge UMETA(DisplayName = "Light Bridge"),
+    LightToShadow UMETA(DisplayName = "Light to Shadow"),
+    ShadowBridge UMETA(DisplayName = "Shadow Bridge"),
+    ShadowIllusion UMETA(DisplayName = "Shadow Illusion"),
+    ChaosFlicker UMETA(DisplayName = "Chaos Flicker"),
+    ChaosTrap UMETA(DisplayName = "Chaos Trap"),
+    ChaosBridge UMETA(DisplayName = "Chaos Bridge"),
+    ShiftChain UMETA(DisplayName = "Shift Chain"),
+    HiddenSurprise UMETA(DisplayName = "Hidden Surprise"),
+    DeceptionPlatform UMETA(DisplayName = "Deception Platform")
+};
+
 UCLASS()
 class GAMEJAM_API AShiftPlatform : public AActor
 {
@@ -29,6 +44,7 @@ public:
     AShiftPlatform();
 
 protected:
+    virtual void OnConstruction(const FTransform& Transform) override;
     virtual void BeginPlay() override;
     virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
 
@@ -37,6 +53,9 @@ protected:
 
     UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "World Shift")
     TObjectPtr<UWorldShiftComponent> WorldShiftComponent;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "World Shift|Prefab")
+    EPlatformPrefabType PrefabType;
 
     UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "World Shift")
     TMap<EWorldState, EPlatformState> WorldBehaviors;
@@ -62,6 +81,7 @@ private:
 
     EPlatformState GetBehaviorForWorld(EWorldState WorldContext) const;
     void ApplyMaterial(UMaterialInterface* Material);
+    void InitializeWorldBehaviorsFromPrefab();
 
     TWeakObjectPtr<AWorldManager> CachedWorldManager;
 


### PR DESCRIPTION
## Summary
- add a platform prefab type enum for common archetypes
- expose a prefab selection property on shift platforms for designers
- auto-populate world behaviors from the selected prefab when no overrides exist

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbf9d1f994832e90535e853827106a