### PR TITLE
Make shift platform timer durations configurable

### DIFF
--- a/Source/GameJam/ShiftPlatform.cpp
+++ b/Source/GameJam/ShiftPlatform.cpp
@@ -20,6 +20,8 @@ AShiftPlatform::AShiftPlatform()
 
     CurrentWorld = EWorldState::Light;
     bTimedSolidCurrentlySolid = false;
+    TimedSolidInterval = 2.0f;
+    PreWarningDuration = 1.0f;
 }
 
 void AShiftPlatform::OnConstruction(const FTransform& Transform)
@@ -175,7 +177,8 @@ void AShiftPlatform::StartTimedSolidCycle()
 
     if (UWorld* World = GetWorld())
     {
-        World->GetTimerManager().SetTimer(TimedSolidTimerHandle, this, &AShiftPlatform::HandleTimedSolidToggle, 2.0f, true, 2.0f);
+        const float Interval = FMath::Max(0.0f, TimedSolidInterval);
+        World->GetTimerManager().SetTimer(TimedSolidTimerHandle, this, &AShiftPlatform::HandleTimedSolidToggle, Interval, true, Interval);
         HandleTimedSolidToggle();
     }
     else
@@ -210,7 +213,8 @@ void AShiftPlatform::HandleTimedSolidToggle()
 
     if (UWorld* World = GetWorld())
     {
-        World->GetTimerManager().SetTimer(PreWarningTimerHandle, this, &AShiftPlatform::CompleteTimedSolidToggle, 1.0f, false);
+        const float WarningDuration = FMath::Max(0.0f, PreWarningDuration);
+        World->GetTimerManager().SetTimer(PreWarningTimerHandle, this, &AShiftPlatform::CompleteTimedSolidToggle, WarningDuration, false);
     }
     else
     {

--- a/Source/GameJam/ShiftPlatform.h
+++ b/Source/GameJam/ShiftPlatform.h
@@ -69,6 +69,12 @@ protected:
     UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "World Shift|Materials")
     TMap<EWorldState, TObjectPtr<UMaterialInterface>> GhostMaterials;
 
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "World Shift|Timed Solid", meta = (ClampMin = "0.0"))
+    float TimedSolidInterval;
+
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "World Shift|Timed Solid", meta = (ClampMin = "0.0"))
+    float PreWarningDuration;
+
     UFUNCTION(BlueprintImplementableEvent, Category = "World Shift|Events")
     void OnPreWarningStart(EWorldState WorldContext);
 


### PR DESCRIPTION
## Summary
- add editable properties for the timed solid and pre-warning timer durations
- use the configured values when scheduling the shift platform timers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcb7509f2c832e92b63acbd922726f