### PR TITLE
Refactor timed solid platforms to use global timers

### DIFF
--- a/Source/GameJam/ShiftPlatform.cpp
+++ b/Source/GameJam/ShiftPlatform.cpp
@@ -3,7 +3,6 @@
 #include "Components/StaticMeshComponent.h"
 #include "Engine/World.h"
 #include "Materials/MaterialInterface.h"
-#include "TimerManager.h"
 #include "WorldManager.h"
 #include "WorldShiftComponent.h"
 
@@ -19,9 +18,6 @@ AShiftPlatform::AShiftPlatform()
     PrefabType = EPlatformPrefabType::LightBridge;
 
     CurrentWorld = EWorldState::Light;
-    bTimedSolidCurrentlySolid = false;
-    TimedSolidInterval = 2.0f;
-    PreWarningDuration = 1.0f;
 }
 
 void AShiftPlatform::OnConstruction(const FTransform& Transform)
@@ -41,6 +37,8 @@ void AShiftPlatform::BeginPlay()
     {
         CachedWorldManager = Manager;
         Manager->OnWorldShifted.AddDynamic(this, &AShiftPlatform::HandleWorldShift);
+        Manager->OnTimedSolidPhaseChanged.AddDynamic(this, &AShiftPlatform::OnGlobalTimedSolidPhaseChanged);
+        Manager->OnTimedSolidPreWarning.AddDynamic(this, &AShiftPlatform::OnGlobalTimedSolidPreWarning);
         HandleWorldShift(Manager->GetCurrentWorld());
     }
     else
@@ -51,11 +49,11 @@ void AShiftPlatform::BeginPlay()
 
 void AShiftPlatform::EndPlay(const EEndPlayReason::Type EndPlayReason)
 {
-    StopTimedSolidCycle();
-
     if (CachedWorldManager.IsValid())
     {
         CachedWorldManager->OnWorldShifted.RemoveDynamic(this, &AShiftPlatform::HandleWorldShift);
+        CachedWorldManager->OnTimedSolidPhaseChanged.RemoveDynamic(this, &AShiftPlatform::OnGlobalTimedSolidPhaseChanged);
+        CachedWorldManager->OnTimedSolidPreWarning.RemoveDynamic(this, &AShiftPlatform::OnGlobalTimedSolidPreWarning);
         CachedWorldManager.Reset();
     }
 
@@ -75,30 +73,32 @@ void AShiftPlatform::ApplyPlatformState(EPlatformState NewState, EWorldState Wor
     switch (NewState)
     {
     case EPlatformState::Solid:
-        StopTimedSolidCycle();
         ApplySolidState();
         break;
     case EPlatformState::Ghost:
-        StopTimedSolidCycle();
         ApplyGhostState(WorldContext);
         break;
     case EPlatformState::Hidden:
-        StopTimedSolidCycle();
         ApplyHiddenState();
         break;
     case EPlatformState::TimedSolid:
         if (WorldContext == EWorldState::Chaos)
         {
-            StartTimedSolidCycle();
+            if (CachedWorldManager.IsValid())
+            {
+                OnGlobalTimedSolidPhaseChanged(CachedWorldManager->IsGlobalTimedSolidSolid());
+            }
+            else
+            {
+                ApplySolidState();
+            }
         }
         else
         {
-            StopTimedSolidCycle();
             ApplySolidState();
         }
         break;
     default:
-        StopTimedSolidCycle();
         ApplySolidState();
         break;
     }
@@ -169,62 +169,14 @@ void AShiftPlatform::ApplyPreWarningState()
     }
 }
 
-void AShiftPlatform::StartTimedSolidCycle()
+void AShiftPlatform::OnGlobalTimedSolidPhaseChanged(bool bNowSolid)
 {
-    StopTimedSolidCycle();
-
-    bTimedSolidCurrentlySolid = false;
-
-    if (UWorld* World = GetWorld())
+    if (GetBehaviorForWorld(CurrentWorld) != EPlatformState::TimedSolid)
     {
-        const float Interval = FMath::Max(0.0f, TimedSolidInterval);
-        World->GetTimerManager().SetTimer(TimedSolidTimerHandle, this, &AShiftPlatform::HandleTimedSolidToggle, Interval, true, Interval);
-        HandleTimedSolidToggle();
-    }
-    else
-    {
-        ApplySolidState();
-    }
-}
-
-void AShiftPlatform::StopTimedSolidCycle()
-{
-    if (UWorld* World = GetWorld())
-    {
-        World->GetTimerManager().ClearTimer(TimedSolidTimerHandle);
-        World->GetTimerManager().ClearTimer(PreWarningTimerHandle);
+        return;
     }
 
-    bTimedSolidCurrentlySolid = false;
-}
-
-void AShiftPlatform::HandleTimedSolidToggle()
-{
-    if (UWorld* World = GetWorld())
-    {
-        World->GetTimerManager().ClearTimer(PreWarningTimerHandle);
-    }
-
-    bTimedSolidCurrentlySolid = !bTimedSolidCurrentlySolid;
-
-    OnPreWarningStart(CurrentWorld);
-
-    ApplyPreWarningState();
-
-    if (UWorld* World = GetWorld())
-    {
-        const float WarningDuration = FMath::Max(0.0f, PreWarningDuration);
-        World->GetTimerManager().SetTimer(PreWarningTimerHandle, this, &AShiftPlatform::CompleteTimedSolidToggle, WarningDuration, false);
-    }
-    else
-    {
-        CompleteTimedSolidToggle();
-    }
-}
-
-void AShiftPlatform::CompleteTimedSolidToggle()
-{
-    if (bTimedSolidCurrentlySolid)
+    if (bNowSolid)
     {
         ApplySolidState();
     }
@@ -232,6 +184,17 @@ void AShiftPlatform::CompleteTimedSolidToggle()
     {
         ApplyGhostState(CurrentWorld);
     }
+}
+
+void AShiftPlatform::OnGlobalTimedSolidPreWarning(bool bWillBeSolid)
+{
+    if (GetBehaviorForWorld(CurrentWorld) != EPlatformState::TimedSolid)
+    {
+        return;
+    }
+
+    ApplyPreWarningState();
+    OnPreWarningStarted(bWillBeSolid);
 }
 
 EPlatformState AShiftPlatform::GetBehaviorForWorld(EWorldState WorldContext) const

--- a/Source/GameJam/ShiftPlatform.h
+++ b/Source/GameJam/ShiftPlatform.h
@@ -9,7 +9,6 @@ class UStaticMeshComponent;
 class UWorldShiftComponent;
 class UMaterialInterface;
 class AWorldManager;
-struct FTimerHandle;
 
 UENUM(BlueprintType)
 enum class EPlatformState : uint8
@@ -69,14 +68,8 @@ protected:
     UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "World Shift|Materials")
     TMap<EWorldState, TObjectPtr<UMaterialInterface>> GhostMaterials;
 
-    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "World Shift|Timed Solid", meta = (ClampMin = "0.0"))
-    float TimedSolidInterval;
-
-    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "World Shift|Timed Solid", meta = (ClampMin = "0.0"))
-    float PreWarningDuration;
-
     UFUNCTION(BlueprintImplementableEvent, Category = "World Shift|Events")
-    void OnPreWarningStart(EWorldState WorldContext);
+    void OnPreWarningStarted(bool bWillBeSolid);
 
 private:
     UFUNCTION()
@@ -88,10 +81,11 @@ private:
     void ApplyHiddenState();
     void ApplyPreWarningState();
 
-    void StartTimedSolidCycle();
-    void StopTimedSolidCycle();
-    void HandleTimedSolidToggle();
-    void CompleteTimedSolidToggle();
+    UFUNCTION()
+    void OnGlobalTimedSolidPhaseChanged(bool bNowSolid);
+
+    UFUNCTION()
+    void OnGlobalTimedSolidPreWarning(bool bWillBeSolid);
 
     EPlatformState GetBehaviorForWorld(EWorldState WorldContext) const;
     void ApplyMaterial(UMaterialInterface* Material);
@@ -99,9 +93,5 @@ private:
 
     TWeakObjectPtr<AWorldManager> CachedWorldManager;
 
-    FTimerHandle TimedSolidTimerHandle;
-    FTimerHandle PreWarningTimerHandle;
-
     EWorldState CurrentWorld;
-    bool bTimedSolidCurrentlySolid;
 };


### PR DESCRIPTION
## Summary
- add world-manager-driven delegates and timers to synchronize timed solid state changes across the level
- subscribe shift platforms to the global events, removing per-platform timers and exposing a pre-warning Blueprint hook

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dcc3da8fc0832e80536b0a3b6a5163