### PR TITLE
Add ghost hint mesh support to shift platforms

### DIFF
--- a/Source/GameJam/ShiftPlatform.h
+++ b/Source/GameJam/ShiftPlatform.h
@@ -50,6 +50,9 @@ protected:
     UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Components")
     TObjectPtr<UStaticMeshComponent> PlatformMesh;
 
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "World Shift|Ghost Hint")
+    TObjectPtr<UStaticMeshComponent> GhostHintMesh;
+
     UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "World Shift")
     TObjectPtr<UWorldShiftComponent> WorldShiftComponent;
 
@@ -67,6 +70,9 @@ protected:
 
     UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "World Shift|Materials")
     TMap<EWorldState, TObjectPtr<UMaterialInterface>> GhostMaterials;
+
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "World Shift|Materials")
+    TMap<EWorldState, TObjectPtr<UMaterialInterface>> GhostHintMaterials;
 
     UFUNCTION(BlueprintImplementableEvent, Category = "World Shift|Events")
     void OnPreWarningStarted(bool bWillBeSolid);
@@ -90,6 +96,7 @@ private:
     EPlatformState GetBehaviorForWorld(EWorldState WorldContext) const;
     void ApplyMaterial(UMaterialInterface* Material);
     void InitializeWorldBehaviorsFromPrefab();
+    void UpdateGhostHint(EWorldState CurrentWorld);
 
     TWeakObjectPtr<AWorldManager> CachedWorldManager;
 


### PR DESCRIPTION
## Summary
- add a dedicated ghost hint static mesh component to shift platforms that mirrors the main mesh
- expose a material map for ghost hint visuals keyed by world state
- update world shift handling to toggle the ghost hint mesh and apply world-specific hint materials when the platform is inactive in the current world

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcd5851ff0832eaee5f6be444147ed