### PR TITLE
Allow TimedSolid platforms in all worlds

### DIFF
--- a/Source/GameJam/ShiftPlatform.cpp
+++ b/Source/GameJam/ShiftPlatform.cpp
@@ -95,16 +95,9 @@ void AShiftPlatform::ApplyPlatformState(EPlatformState NewState, EWorldState Wor
         ApplyHiddenState();
         break;
     case EPlatformState::TimedSolid:
-        if (WorldContext == EWorldState::Chaos)
+        if (CachedWorldManager.IsValid())
         {
-            if (CachedWorldManager.IsValid())
-            {
-                OnGlobalTimedSolidPhaseChanged(CachedWorldManager->IsGlobalTimedSolidSolid());
-            }
-            else
-            {
-                ApplySolidState();
-            }
+            OnGlobalTimedSolidPhaseChanged(CachedWorldManager->IsGlobalTimedSolidSolid());
         }
         else
         {


### PR DESCRIPTION
## Summary
- allow TimedSolid platforms to operate in any world instead of Chaos-only
- default to solid state when the world manager is unavailable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd6c4914c0832e911b438fa4f7c6f9