### PR TITLE
Refactor world shift behavior into reusable component

### DIFF
--- a/Source/GameJam/ShiftPlatform.cpp
+++ b/Source/GameJam/ShiftPlatform.cpp
@@ -1,10 +1,7 @@
 #include "ShiftPlatform.h"
 
 #include "Components/StaticMeshComponent.h"
-#include "Engine/World.h"
-#include "Materials/MaterialInterface.h"
-#include "WorldManager.h"
-#include "WorldShiftComponent.h"
+#include "WorldShiftBehaviorComponent.h"
 
 AShiftPlatform::AShiftPlatform()
 {
@@ -13,311 +10,32 @@ AShiftPlatform::AShiftPlatform()
     PlatformMesh = CreateDefaultSubobject<UStaticMeshComponent>(TEXT("PlatformMesh"));
     RootComponent = PlatformMesh;
 
-    GhostHintMesh = CreateDefaultSubobject<UStaticMeshComponent>(TEXT("GhostHintMesh"));
-    GhostHintMesh->SetupAttachment(PlatformMesh);
-    GhostHintMesh->SetCollisionEnabled(ECollisionEnabled::NoCollision);
-    GhostHintMesh->SetVisibility(false, true);
-    GhostHintMesh->SetHiddenInGame(true);
-    GhostHintMesh->SetRelativeTransform(FTransform::Identity);
+    WorldShiftBehavior = CreateDefaultSubobject<UWorldShiftBehaviorComponent>(TEXT("WorldShiftBehavior"));
+    WorldShiftBehavior->SetTargetMesh(PlatformMesh);
 
-    WorldShiftComponent = CreateDefaultSubobject<UWorldShiftComponent>(TEXT("WorldShiftComponent"));
+    if (UStaticMeshComponent* GhostHint = CreateDefaultSubobject<UStaticMeshComponent>(TEXT("GhostHintMesh")))
+    {
+        GhostHint->SetupAttachment(PlatformMesh);
+        GhostHint->SetCollisionEnabled(ECollisionEnabled::NoCollision);
+        GhostHint->SetVisibility(false, true);
+        GhostHint->SetHiddenInGame(true);
+        GhostHint->SetRelativeTransform(FTransform::Identity);
+        WorldShiftBehavior->SetGhostHintMesh(GhostHint);
+    }
 
     PrefabType = EPlatformPrefabType::LightBridge;
-
-    CurrentWorld = EWorldState::Light;
-    //bTimedSolidCurrentlySolid = false;
-    //TimedSolidInterval = 5.0f;
-    //PreWarningDuration = 1.0f;
 }
 
 void AShiftPlatform::OnConstruction(const FTransform& Transform)
 {
     Super::OnConstruction(Transform);
 
-    InitializeWorldBehaviorsFromPrefab();
-
-    UpdateGhostHint(CurrentWorld);
-}
-
-void AShiftPlatform::BeginPlay()
-{
-    Super::BeginPlay();
-
-    InitializeWorldBehaviorsFromPrefab();
-
-    if (AWorldManager* Manager = AWorldManager::Get(GetWorld()))
+    if (WorldShiftBehavior)
     {
-        CachedWorldManager = Manager;
-        Manager->OnWorldShifted.AddDynamic(this, &AShiftPlatform::HandleWorldShift);
-        Manager->OnTimedSolidPhaseChanged.AddDynamic(this, &AShiftPlatform::OnGlobalTimedSolidPhaseChanged);
-        Manager->OnTimedSolidPreWarning.AddDynamic(this, &AShiftPlatform::OnGlobalTimedSolidPreWarning);
-        HandleWorldShift(Manager->GetCurrentWorld());
+        WorldShiftBehavior->SetTargetMesh(PlatformMesh);
+        WorldShiftBehavior->EnsureWorldBehaviorsFromPrefab(PrefabType);
+        WorldShiftBehavior->RefreshGhostHintPreview(WorldShiftBehavior->CurrentWorld);
     }
-    else
-    {
-        HandleWorldShift(CurrentWorld);
-    }
-}
-
-void AShiftPlatform::EndPlay(const EEndPlayReason::Type EndPlayReason)
-{
-    if (CachedWorldManager.IsValid())
-    {
-        CachedWorldManager->OnWorldShifted.RemoveDynamic(this, &AShiftPlatform::HandleWorldShift);
-        CachedWorldManager->OnTimedSolidPhaseChanged.RemoveDynamic(this, &AShiftPlatform::OnGlobalTimedSolidPhaseChanged);
-        CachedWorldManager->OnTimedSolidPreWarning.RemoveDynamic(this, &AShiftPlatform::OnGlobalTimedSolidPreWarning);
-        CachedWorldManager.Reset();
-    }
-
-    Super::EndPlay(EndPlayReason);
-}
-
-void AShiftPlatform::HandleWorldShift(EWorldState NewWorld)
-{
-    CurrentWorld = NewWorld;
-    const EPlatformState Behavior = GetBehaviorForWorld(NewWorld);
-
-    ApplyPlatformState(Behavior, NewWorld);
-    UpdateGhostHint(NewWorld);
-}
-
-void AShiftPlatform::ApplyPlatformState(EPlatformState NewState, EWorldState WorldContext)
-{
-    switch (NewState)
-    {
-    case EPlatformState::Solid:
-        ApplySolidState();
-        break;
-    case EPlatformState::Ghost:
-        ApplyGhostState(WorldContext);
-        break;
-    case EPlatformState::Hidden:
-        ApplyHiddenState();
-        break;
-    case EPlatformState::TimedSolid:
-        if (CachedWorldManager.IsValid())
-        {
-            OnGlobalTimedSolidPhaseChanged(CachedWorldManager->IsGlobalTimedSolidSolid());
-        }
-        else
-        {
-            ApplySolidState();
-        }
-        break;
-    default:
-        ApplySolidState();
-        break;
-    }
-}
-
-void AShiftPlatform::ApplySolidState()
-{
-    if (!PlatformMesh)
-    {
-        return;
-    }
-
-   // PlatformMesh->SetHiddenInGame(false);
-    PlatformMesh->SetVisibility(true, true);
-    PlatformMesh->SetCollisionEnabled(ECollisionEnabled::QueryAndPhysics);
-
-    if (SolidMaterial)
-    {
-        ApplyMaterial(SolidMaterial.Get());
-    }
-}
-
-void AShiftPlatform::ApplyGhostState(EWorldState WorldContext)
-{
-    if (!PlatformMesh)
-    {
-        return;
-    }
-
-   // PlatformMesh->SetHiddenInGame(false);
-   PlatformMesh->SetVisibility(true, true);
-    PlatformMesh->SetCollisionEnabled(ECollisionEnabled::NoCollision);
-
-    if (const TObjectPtr<UMaterialInterface>* MaterialPtr = GhostMaterials.Find(WorldContext))
-    {
-        if (UMaterialInterface* Material = MaterialPtr->Get())
-        {
-            ApplyMaterial(Material);
-        }
-    }
-}
-
-void AShiftPlatform::ApplyHiddenState()
-{
-    if (!PlatformMesh)
-    {
-        return;
-    }
-
-    PlatformMesh->SetCollisionEnabled(ECollisionEnabled::NoCollision);
-
-    PlatformMesh->SetVisibility(false, true);
-}
-
-void AShiftPlatform::ApplyPreWarningState()
-{
-    if (!PlatformMesh)
-    {
-        return;
-    }
-
-    PlatformMesh->SetVisibility(true, true);
-    PlatformMesh->SetCollisionEnabled(ECollisionEnabled::NoCollision);
-
-    if (PreWarningMaterial)
-    {
-        ApplyMaterial(PreWarningMaterial.Get());
-    }
-}
-
-void AShiftPlatform::OnGlobalTimedSolidPhaseChanged(bool bNowSolid)
-{
-    if (GetBehaviorForWorld(CurrentWorld) != EPlatformState::TimedSolid)
-    {
-        return;
-    }
-
-    if (bNowSolid)
-    {
-        ApplySolidState();
-    }
-    else
-    {
-        ApplyGhostState(CurrentWorld);
-    }
-}
-
-void AShiftPlatform::OnGlobalTimedSolidPreWarning(bool bWillBeSolid)
-{
-    if (GetBehaviorForWorld(CurrentWorld) != EPlatformState::TimedSolid)
-    {
-        return;
-    }
-
-    ApplyPreWarningState();
-    OnPreWarningStarted(bWillBeSolid);
-}
-
-EPlatformState AShiftPlatform::GetBehaviorForWorld(EWorldState WorldContext) const
-{
-    if (const EPlatformState* FoundState = WorldBehaviors.Find(WorldContext))
-    {
-        return *FoundState;
-    }
-
-    return EPlatformState::Solid;
-}
-
-void AShiftPlatform::ApplyMaterial(UMaterialInterface* Material)
-{
-    if (!PlatformMesh || !Material)
-    {
-        return;
-    }
-
-    const int32 MaterialCount = PlatformMesh->GetNumMaterials();
-    for (int32 MaterialIndex = 0; MaterialIndex < MaterialCount; ++MaterialIndex)
-    {
-        PlatformMesh->SetMaterial(MaterialIndex, Material);
-    }
-}
-
-void AShiftPlatform::InitializeWorldBehaviorsFromPrefab()
-{
-    if (WorldBehaviors.Num() > 0)
-    {
-        return;
-    }
-
-    auto Configure = [this](EPlatformState LightState, EPlatformState ShadowState, EPlatformState ChaosState)
-    {
-        WorldBehaviors.Add(EWorldState::Light, LightState);
-        WorldBehaviors.Add(EWorldState::Shadow, ShadowState);
-        WorldBehaviors.Add(EWorldState::Chaos, ChaosState);
-    };
-
-    switch (PrefabType)
-    {
-    case EPlatformPrefabType::LightBridge:
-        Configure(EPlatformState::Solid, EPlatformState::Hidden, EPlatformState::Hidden);
-        break;
-    case EPlatformPrefabType::LightToShadow:
-        Configure(EPlatformState::Solid, EPlatformState::Ghost, EPlatformState::Hidden);
-        break;
-    case EPlatformPrefabType::ShadowBridge:
-        Configure(EPlatformState::Hidden, EPlatformState::Solid, EPlatformState::Hidden);
-        break;
-    case EPlatformPrefabType::ShadowIllusion:
-        Configure(EPlatformState::Solid, EPlatformState::Ghost, EPlatformState::Solid);
-        break;
-    case EPlatformPrefabType::ChaosFlicker:
-        Configure(EPlatformState::Hidden, EPlatformState::Hidden, EPlatformState::TimedSolid);
-        break;
-    case EPlatformPrefabType::ChaosTrap:
-        Configure(EPlatformState::Solid, EPlatformState::Solid, EPlatformState::Ghost);
-        break;
-    case EPlatformPrefabType::ChaosBridge:
-        Configure(EPlatformState::Hidden, EPlatformState::Hidden, EPlatformState::Solid);
-        break;
-    case EPlatformPrefabType::ShiftChain:
-        Configure(EPlatformState::Solid, EPlatformState::Solid, EPlatformState::TimedSolid);
-        break;
-    case EPlatformPrefabType::HiddenSurprise:
-        Configure(EPlatformState::Hidden, EPlatformState::Ghost, EPlatformState::Solid);
-        break;
-    case EPlatformPrefabType::DeceptionPlatform:
-        Configure(EPlatformState::Solid, EPlatformState::Ghost, EPlatformState::TimedSolid);
-        break;
-    default:
-        Configure(EPlatformState::Solid, EPlatformState::Ghost, EPlatformState::TimedSolid);
-        break;
-    }
-}
-
-void AShiftPlatform::UpdateGhostHint(EWorldState CurrentWorldState)
-{
-    if (!GhostHintMesh)
-    {
-        return;
-    }
-
-    const EPlatformState CurrentState = GetBehaviorForWorld(CurrentWorldState);
-    const bool bIsActiveInCurrentWorld = CurrentState == EPlatformState::Solid || CurrentState == EPlatformState::TimedSolid;
-    if (bIsActiveInCurrentWorld)
-    {
-        GhostHintMesh->SetVisibility(false, true);
-        GhostHintMesh->SetHiddenInGame(true);
-        return;
-    }
-
-    for (const TPair<EWorldState, EPlatformState>& Pair : WorldBehaviors)
-    {
-        if (Pair.Key == CurrentWorldState)
-        {
-            continue;
-        }
-
-        if (Pair.Value == EPlatformState::Solid || Pair.Value == EPlatformState::TimedSolid)
-        {
-            GhostHintMesh->SetVisibility(true, true);
-            GhostHintMesh->SetHiddenInGame(false);
-
-            if (UMaterialInterface* HintMaterial = GhostHintMaterials.FindRef(Pair.Key))
-            {
-                GhostHintMesh->SetMaterial(0, HintMaterial);
-            }
-
-            return;
-        }
-    }
-
-    GhostHintMesh->SetVisibility(false, true);
-    GhostHintMesh->SetHiddenInGame(true);
 }
 
 /*

--- a/Source/GameJam/ShiftPlatform.h
+++ b/Source/GameJam/ShiftPlatform.h
@@ -6,9 +6,7 @@
 #include "ShiftPlatform.generated.h"
 
 class UStaticMeshComponent;
-class UWorldShiftComponent;
-class UMaterialInterface;
-class AWorldManager;
+class UWorldShiftBehaviorComponent;
 
 UENUM(BlueprintType)
 enum class EPlatformState : uint8
@@ -44,61 +42,13 @@ public:
 
 protected:
     virtual void OnConstruction(const FTransform& Transform) override;
-    virtual void BeginPlay() override;
-    virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
 
     UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Components")
     TObjectPtr<UStaticMeshComponent> PlatformMesh;
 
-    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "World Shift|Ghost Hint")
-    TObjectPtr<UStaticMeshComponent> GhostHintMesh;
-
     UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "World Shift")
-    TObjectPtr<UWorldShiftComponent> WorldShiftComponent;
+    TObjectPtr<UWorldShiftBehaviorComponent> WorldShiftBehavior;
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "World Shift|Prefab")
     EPlatformPrefabType PrefabType;
-
-    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "World Shift")
-    TMap<EWorldState, EPlatformState> WorldBehaviors;
-
-    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "World Shift|Materials")
-    TObjectPtr<UMaterialInterface> SolidMaterial;
-
-    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "World Shift|Materials")
-    TObjectPtr<UMaterialInterface> PreWarningMaterial;
-
-    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "World Shift|Materials")
-    TMap<EWorldState, TObjectPtr<UMaterialInterface>> GhostMaterials;
-
-    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "World Shift|Materials")
-    TMap<EWorldState, TObjectPtr<UMaterialInterface>> GhostHintMaterials;
-
-    UFUNCTION(BlueprintImplementableEvent, Category = "World Shift|Events")
-    void OnPreWarningStarted(bool bWillBeSolid);
-
-private:
-    UFUNCTION()
-    void HandleWorldShift(EWorldState NewWorld);
-
-    void ApplyPlatformState(EPlatformState NewState, EWorldState WorldContext);
-    void ApplySolidState();
-    void ApplyGhostState(EWorldState WorldContext);
-    void ApplyHiddenState();
-    void ApplyPreWarningState();
-
-    UFUNCTION()
-    void OnGlobalTimedSolidPhaseChanged(bool bNowSolid);
-
-    UFUNCTION()
-    void OnGlobalTimedSolidPreWarning(bool bWillBeSolid);
-
-    EPlatformState GetBehaviorForWorld(EWorldState WorldContext) const;
-    void ApplyMaterial(UMaterialInterface* Material);
-    void InitializeWorldBehaviorsFromPrefab();
-    void UpdateGhostHint(EWorldState CurrentWorld);
-
-    TWeakObjectPtr<AWorldManager> CachedWorldManager;
-
-    EWorldState CurrentWorld;
 };

--- a/Source/GameJam/WorldShiftBehaviorComponent.cpp
+++ b/Source/GameJam/WorldShiftBehaviorComponent.cpp
@@ -1,0 +1,372 @@
+#include "WorldShiftBehaviorComponent.h"
+
+#include "Components/StaticMeshComponent.h"
+#include "Materials/MaterialInterface.h"
+#include "ShiftPlatform.h"
+#include "WorldManager.h"
+
+UWorldShiftBehaviorComponent::UWorldShiftBehaviorComponent()
+{
+    PrimaryComponentTick.bCanEverTick = false;
+
+    CurrentWorld = EWorldState::Light;
+    CurrentState = EPlatformState::Solid;
+}
+
+void UWorldShiftBehaviorComponent::SetTargetMesh(UStaticMeshComponent* InMesh)
+{
+    TargetMesh = InMesh;
+}
+
+void UWorldShiftBehaviorComponent::SetGhostHintMesh(UStaticMeshComponent* InMesh)
+{
+    GhostHintMesh = InMesh;
+
+    if (GhostHintMesh)
+    {
+        GhostHintMesh->SetCollisionEnabled(ECollisionEnabled::NoCollision);
+        GhostHintMesh->SetVisibility(false, true);
+        GhostHintMesh->SetHiddenInGame(true);
+    }
+}
+
+void UWorldShiftBehaviorComponent::ResetWorldBehaviors()
+{
+    WorldBehaviors.Reset();
+}
+
+void UWorldShiftBehaviorComponent::EnsureWorldBehaviorsFromPrefab(EPlatformPrefabType PrefabType)
+{
+    if (WorldBehaviors.Num() > 0)
+    {
+        return;
+    }
+
+    auto Configure = [this](EPlatformState LightState, EPlatformState ShadowState, EPlatformState ChaosState)
+    {
+        WorldBehaviors.Add(EWorldState::Light, LightState);
+        WorldBehaviors.Add(EWorldState::Shadow, ShadowState);
+        WorldBehaviors.Add(EWorldState::Chaos, ChaosState);
+    };
+
+    switch (PrefabType)
+    {
+    case EPlatformPrefabType::LightBridge:
+        Configure(EPlatformState::Solid, EPlatformState::Hidden, EPlatformState::Hidden);
+        break;
+    case EPlatformPrefabType::LightToShadow:
+        Configure(EPlatformState::Solid, EPlatformState::Ghost, EPlatformState::Hidden);
+        break;
+    case EPlatformPrefabType::ShadowBridge:
+        Configure(EPlatformState::Hidden, EPlatformState::Solid, EPlatformState::Hidden);
+        break;
+    case EPlatformPrefabType::ShadowIllusion:
+        Configure(EPlatformState::Solid, EPlatformState::Ghost, EPlatformState::Solid);
+        break;
+    case EPlatformPrefabType::ChaosFlicker:
+        Configure(EPlatformState::Hidden, EPlatformState::Hidden, EPlatformState::TimedSolid);
+        break;
+    case EPlatformPrefabType::ChaosTrap:
+        Configure(EPlatformState::Solid, EPlatformState::Solid, EPlatformState::Ghost);
+        break;
+    case EPlatformPrefabType::ChaosBridge:
+        Configure(EPlatformState::Hidden, EPlatformState::Hidden, EPlatformState::Solid);
+        break;
+    case EPlatformPrefabType::ShiftChain:
+        Configure(EPlatformState::Solid, EPlatformState::Solid, EPlatformState::TimedSolid);
+        break;
+    case EPlatformPrefabType::HiddenSurprise:
+        Configure(EPlatformState::Hidden, EPlatformState::Ghost, EPlatformState::Solid);
+        break;
+    case EPlatformPrefabType::DeceptionPlatform:
+        Configure(EPlatformState::Solid, EPlatformState::Ghost, EPlatformState::TimedSolid);
+        break;
+    default:
+        Configure(EPlatformState::Solid, EPlatformState::Ghost, EPlatformState::TimedSolid);
+        break;
+    }
+}
+
+void UWorldShiftBehaviorComponent::RefreshGhostHintPreview(EWorldState PreviewWorld)
+{
+    UpdateGhostHint(PreviewWorld);
+}
+
+void UWorldShiftBehaviorComponent::BeginPlay()
+{
+    Super::BeginPlay();
+
+    InitializeFromOwner();
+    BindToWorldManager();
+
+    if (CachedWorldManager.IsValid())
+    {
+        CurrentWorld = CachedWorldManager->GetCurrentWorld();
+        HandleWorldShift(CurrentWorld);
+    }
+    else
+    {
+        HandleWorldShift(CurrentWorld);
+    }
+}
+
+void UWorldShiftBehaviorComponent::EndPlay(const EEndPlayReason::Type EndPlayReason)
+{
+    UnbindFromWorldManager();
+
+    Super::EndPlay(EndPlayReason);
+}
+
+void UWorldShiftBehaviorComponent::OnRegister()
+{
+    Super::OnRegister();
+
+    InitializeFromOwner();
+}
+
+void UWorldShiftBehaviorComponent::InitializeFromOwner()
+{
+    if (!TargetMesh)
+    {
+        if (const AActor* OwnerActor = GetOwner())
+        {
+            TargetMesh = Cast<UStaticMeshComponent>(OwnerActor->GetRootComponent());
+        }
+    }
+
+    if (TargetMesh)
+    {
+        TargetMesh->SetVisibility(true, true);
+    }
+}
+
+void UWorldShiftBehaviorComponent::BindToWorldManager()
+{
+    if (CachedWorldManager.IsValid())
+    {
+        return;
+    }
+
+    if (AWorldManager* Manager = AWorldManager::Get(GetWorld()))
+    {
+        CachedWorldManager = Manager;
+        Manager->OnWorldShifted.AddDynamic(this, &UWorldShiftBehaviorComponent::HandleWorldShift);
+        Manager->OnTimedSolidPhaseChanged.AddDynamic(this, &UWorldShiftBehaviorComponent::HandleGlobalTimedSolidPhaseChanged);
+        Manager->OnTimedSolidPreWarning.AddDynamic(this, &UWorldShiftBehaviorComponent::HandleGlobalTimedSolidPreWarning);
+    }
+}
+
+void UWorldShiftBehaviorComponent::UnbindFromWorldManager()
+{
+    if (!CachedWorldManager.IsValid())
+    {
+        return;
+    }
+
+    if (AWorldManager* Manager = CachedWorldManager.Get())
+    {
+        Manager->OnWorldShifted.RemoveDynamic(this, &UWorldShiftBehaviorComponent::HandleWorldShift);
+        Manager->OnTimedSolidPhaseChanged.RemoveDynamic(this, &UWorldShiftBehaviorComponent::HandleGlobalTimedSolidPhaseChanged);
+        Manager->OnTimedSolidPreWarning.RemoveDynamic(this, &UWorldShiftBehaviorComponent::HandleGlobalTimedSolidPreWarning);
+    }
+
+    CachedWorldManager.Reset();
+}
+
+void UWorldShiftBehaviorComponent::HandleWorldShift(EWorldState NewWorld)
+{
+    CurrentWorld = NewWorld;
+    const EPlatformState NewState = GetBehaviorForWorld(NewWorld);
+    ApplyPlatformState(NewState, NewWorld);
+    UpdateGhostHint(NewWorld);
+    CurrentState = NewState;
+    OnShiftStateChanged(NewState, NewWorld);
+}
+
+void UWorldShiftBehaviorComponent::HandleGlobalTimedSolidPhaseChanged(bool bNowSolid)
+{
+    if (GetBehaviorForWorld(CurrentWorld) != EPlatformState::TimedSolid)
+    {
+        return;
+    }
+
+    if (bNowSolid)
+    {
+        ApplySolidState();
+    }
+    else
+    {
+        ApplyGhostState(CurrentWorld);
+    }
+}
+
+void UWorldShiftBehaviorComponent::HandleGlobalTimedSolidPreWarning(bool bWillBeSolid)
+{
+    if (GetBehaviorForWorld(CurrentWorld) != EPlatformState::TimedSolid)
+    {
+        return;
+    }
+
+    ApplyPreWarningState();
+    OnPreWarningStarted(bWillBeSolid);
+}
+
+void UWorldShiftBehaviorComponent::ApplyPlatformState(EPlatformState NewState, EWorldState WorldContext)
+{
+    switch (NewState)
+    {
+    case EPlatformState::Solid:
+        ApplySolidState();
+        break;
+    case EPlatformState::Ghost:
+        ApplyGhostState(WorldContext);
+        break;
+    case EPlatformState::Hidden:
+        ApplyHiddenState();
+        break;
+    case EPlatformState::TimedSolid:
+        if (CachedWorldManager.IsValid())
+        {
+            HandleGlobalTimedSolidPhaseChanged(CachedWorldManager->IsGlobalTimedSolidSolid());
+        }
+        else
+        {
+            ApplySolidState();
+        }
+        break;
+    default:
+        ApplySolidState();
+        break;
+    }
+}
+
+void UWorldShiftBehaviorComponent::ApplySolidState()
+{
+    if (!TargetMesh)
+    {
+        return;
+    }
+
+    TargetMesh->SetVisibility(true, true);
+    TargetMesh->SetCollisionEnabled(ECollisionEnabled::QueryAndPhysics);
+
+    if (SolidMaterial)
+    {
+        ApplyMaterial(SolidMaterial.Get());
+    }
+}
+
+void UWorldShiftBehaviorComponent::ApplyGhostState(EWorldState WorldContext)
+{
+    if (!TargetMesh)
+    {
+        return;
+    }
+
+    TargetMesh->SetVisibility(true, true);
+    TargetMesh->SetCollisionEnabled(ECollisionEnabled::NoCollision);
+
+    if (const TObjectPtr<UMaterialInterface>* MaterialPtr = GhostMaterials.Find(WorldContext))
+    {
+        if (UMaterialInterface* Material = MaterialPtr->Get())
+        {
+            ApplyMaterial(Material);
+        }
+    }
+}
+
+void UWorldShiftBehaviorComponent::ApplyHiddenState()
+{
+    if (!TargetMesh)
+    {
+        return;
+    }
+
+    TargetMesh->SetVisibility(false, true);
+    TargetMesh->SetCollisionEnabled(ECollisionEnabled::NoCollision);
+}
+
+void UWorldShiftBehaviorComponent::ApplyPreWarningState()
+{
+    if (!TargetMesh)
+    {
+        return;
+    }
+
+    TargetMesh->SetVisibility(true, true);
+    TargetMesh->SetCollisionEnabled(ECollisionEnabled::NoCollision);
+
+    if (PreWarningMaterial)
+    {
+        ApplyMaterial(PreWarningMaterial.Get());
+    }
+}
+
+void UWorldShiftBehaviorComponent::ApplyMaterial(UMaterialInterface* Material) const
+{
+    if (!TargetMesh || !Material)
+    {
+        return;
+    }
+
+    const int32 MaterialCount = TargetMesh->GetNumMaterials();
+    for (int32 MaterialIndex = 0; MaterialIndex < MaterialCount; ++MaterialIndex)
+    {
+        TargetMesh->SetMaterial(MaterialIndex, Material);
+    }
+}
+
+void UWorldShiftBehaviorComponent::UpdateGhostHint(EWorldState WorldContext)
+{
+    if (!GhostHintMesh)
+    {
+        return;
+    }
+
+    const EPlatformState Behavior = GetBehaviorForWorld(WorldContext);
+    const bool bActiveInCurrentWorld = Behavior == EPlatformState::Solid || Behavior == EPlatformState::TimedSolid;
+
+    if (bActiveInCurrentWorld)
+    {
+        GhostHintMesh->SetVisibility(false, true);
+        GhostHintMesh->SetHiddenInGame(true);
+        OnGhostHintUpdated();
+        return;
+    }
+
+    for (const TPair<EWorldState, EPlatformState>& Pair : WorldBehaviors)
+    {
+        if (Pair.Key == WorldContext)
+        {
+            continue;
+        }
+
+        if (Pair.Value == EPlatformState::Solid || Pair.Value == EPlatformState::TimedSolid)
+        {
+            GhostHintMesh->SetVisibility(true, true);
+            GhostHintMesh->SetHiddenInGame(false);
+
+            if (UMaterialInterface* HintMaterial = GhostHintMaterials.FindRef(Pair.Key))
+            {
+                GhostHintMesh->SetMaterial(0, HintMaterial);
+            }
+
+            OnGhostHintUpdated();
+            return;
+        }
+    }
+
+    GhostHintMesh->SetVisibility(false, true);
+    GhostHintMesh->SetHiddenInGame(true);
+    OnGhostHintUpdated();
+}
+
+EPlatformState UWorldShiftBehaviorComponent::GetBehaviorForWorld(EWorldState WorldContext) const
+{
+    if (const EPlatformState* FoundState = WorldBehaviors.Find(WorldContext))
+    {
+        return *FoundState;
+    }
+
+    return EPlatformState::Solid;
+}

--- a/Source/GameJam/WorldShiftBehaviorComponent.h
+++ b/Source/GameJam/WorldShiftBehaviorComponent.h
@@ -1,0 +1,123 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+#include "WorldShiftTypes.h"
+#include "WorldShiftBehaviorComponent.generated.h"
+
+class UStaticMeshComponent;
+class UMaterialInterface;
+class AWorldManager;
+enum class EPlatformPrefabType : uint8;
+enum class EPlatformState : uint8;
+
+/**
+ * Component that applies world shift behavior to an owning actor.
+ * The component is responsible for reacting to world changes, swapping
+ * materials, toggling collision, and driving ghost hint visualization.
+ */
+UCLASS(ClassGroup = (WorldShift), BlueprintType, meta = (BlueprintSpawnableComponent))
+class GAMEJAM_API UWorldShiftBehaviorComponent : public UActorComponent
+{
+    GENERATED_BODY()
+
+public:
+    UWorldShiftBehaviorComponent();
+
+    /** Root mesh that will receive the visibility, collision, and material changes. */
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "World Shift|Setup")
+    TObjectPtr<UStaticMeshComponent> TargetMesh;
+
+    /** Optional ghost hint mesh that is toggled based on future solid states. */
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "World Shift|Ghost Hint")
+    TObjectPtr<UStaticMeshComponent> GhostHintMesh;
+
+    /** Per-world behavior mapping. */
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "World Shift")
+    TMap<EWorldState, EPlatformState> WorldBehaviors;
+
+    /** Material applied when the mesh is solid. */
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "World Shift|Materials")
+    TObjectPtr<UMaterialInterface> SolidMaterial;
+
+    /** Material applied during the global pre-warning window. */
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "World Shift|Materials")
+    TObjectPtr<UMaterialInterface> PreWarningMaterial;
+
+    /** Ghost materials keyed by the world they correspond to. */
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "World Shift|Materials")
+    TMap<EWorldState, TObjectPtr<UMaterialInterface>> GhostMaterials;
+
+    /** Hint materials keyed by the world where the platform becomes solid. */
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "World Shift|Materials")
+    TMap<EWorldState, TObjectPtr<UMaterialInterface>> GhostHintMaterials;
+
+    /** Accessor to the current world tracked by the component. */
+    UPROPERTY(VisibleInstanceOnly, BlueprintReadOnly, Category = "World Shift")
+    EWorldState CurrentWorld;
+
+    /** Accessor to the current platform state tracked by the component. */
+    UPROPERTY(VisibleInstanceOnly, BlueprintReadOnly, Category = "World Shift")
+    EPlatformState CurrentState;
+
+    /** Assigns the mesh that should receive visibility/material updates. */
+    void SetTargetMesh(UStaticMeshComponent* InMesh);
+
+    /** Assigns the optional ghost hint mesh managed by the component. */
+    void SetGhostHintMesh(UStaticMeshComponent* InMesh);
+
+    /** Clears and sets up the behavior map from a prefab definition. */
+    void EnsureWorldBehaviorsFromPrefab(EPlatformPrefabType PrefabType);
+
+    /** Clears the behavior map. */
+    void ResetWorldBehaviors();
+
+    /** Forces the ghost hint mesh to refresh using the provided preview world. */
+    void RefreshGhostHintPreview(EWorldState PreviewWorld);
+
+    /** Blueprint hook fired when the platform state changes. */
+    UFUNCTION(BlueprintImplementableEvent, Category = "World Shift|Events")
+    void OnShiftStateChanged(EPlatformState NewState, EWorldState WorldContext);
+
+    /** Blueprint hook fired when the pre-warning window begins. */
+    UFUNCTION(BlueprintImplementableEvent, Category = "World Shift|Events")
+    void OnPreWarningStarted(bool bWillBeSolid);
+
+    /** Blueprint hook fired when the ghost hint mesh gets updated. */
+    UFUNCTION(BlueprintImplementableEvent, Category = "World Shift|Events")
+    void OnGhostHintUpdated();
+
+protected:
+    virtual void BeginPlay() override;
+    virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
+    virtual void OnRegister() override;
+
+private:
+    void InitializeFromOwner();
+    void BindToWorldManager();
+
+    UFUNCTION()
+    void HandleWorldShift(EWorldState NewWorld);
+
+    UFUNCTION()
+    void HandleGlobalTimedSolidPhaseChanged(bool bNowSolid);
+
+    UFUNCTION()
+    void HandleGlobalTimedSolidPreWarning(bool bWillBeSolid);
+
+    void ApplyPlatformState(EPlatformState NewState, EWorldState WorldContext);
+    void ApplySolidState();
+    void ApplyGhostState(EWorldState WorldContext);
+    void ApplyHiddenState();
+    void ApplyPreWarningState();
+    void ApplyMaterial(UMaterialInterface* Material) const;
+
+    void UpdateGhostHint(EWorldState WorldContext);
+
+    EPlatformState GetBehaviorForWorld(EWorldState WorldContext) const;
+
+    void UnbindFromWorldManager();
+
+    TWeakObjectPtr<AWorldManager> CachedWorldManager;
+};
+


### PR DESCRIPTION
## Summary
- Extract the world shifting logic into a reusable UWorldShiftBehaviorComponent that manages materials, collision, ghost hints, and WorldManager events
- Update AShiftPlatform to configure prefab behaviors via the component while keeping only its mesh and prefab selection

## Testing
- Not run (Unreal project build/tests not executed in container)


------
https://chatgpt.com/codex/tasks/task_e_68deb4b40628832e9d6f7f6ce99778bb