### PR TITLE
Hook player character up to world shift effects

### DIFF
--- a/Source/GameJam/GameJamCharacter.cpp
+++ b/Source/GameJam/GameJamCharacter.cpp
@@ -15,6 +15,7 @@
 #include "Math/UnrealMathUtility.h"
 #include "GameJam.h"
 #include "WorldManager.h"
+#include "WorldShiftEffectsComponent.h"
 
 AGameJamCharacter::AGameJamCharacter()
 {
@@ -53,8 +54,29 @@ AGameJamCharacter::AGameJamCharacter()
         FollowCamera->SetupAttachment(CameraBoom, USpringArmComponent::SocketName);
         FollowCamera->bUsePawnControlRotation = false;
 
-	// Note: The skeletal mesh and anim blueprint references on the Mesh component (inherited from Character) 
-	// are set in the derived blueprint asset named ThirdPersonCharacter (to avoid direct content references in C++)
+        // Create the world shift effects component responsible for audiovisual feedback
+        WorldShiftEffects = CreateDefaultSubobject<UWorldShiftEffectsComponent>(TEXT("WorldShiftEffects"));
+
+        // Note: The skeletal mesh and anim blueprint references on the Mesh component (inherited from Character)
+        // are set in the derived blueprint asset named ThirdPersonCharacter (to avoid direct content references in C++)
+}
+
+void AGameJamCharacter::BeginPlay()
+{
+        Super::BeginPlay();
+
+        if (!WorldShiftEffects)
+        {
+                return;
+        }
+
+        if (UWorld* World = GetWorld())
+        {
+                if (AWorldManager* Manager = AWorldManager::Get(World))
+                {
+                        Manager->OnWorldShifted.AddDynamic(WorldShiftEffects, &UWorldShiftEffectsComponent::TriggerWorldShiftEffects);
+                }
+        }
 }
 
 void AGameJamCharacter::SetupPlayerInputComponent(UInputComponent* PlayerInputComponent)

--- a/Source/GameJam/GameJamCharacter.h
+++ b/Source/GameJam/GameJamCharacter.h
@@ -11,6 +11,7 @@ class USpringArmComponent;
 class UCameraComponent;
 class UInputAction;
 struct FInputActionValue;
+class UWorldShiftEffectsComponent;
 
 DECLARE_LOG_CATEGORY_EXTERN(LogTemplateCharacter, Log, All);
 
@@ -27,9 +28,13 @@ class AGameJamCharacter : public ACharacter
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category="Components", meta = (AllowPrivateAccess = "true"))
 	USpringArmComponent* CameraBoom;
 
-	/** Follow camera */
-	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category="Components", meta = (AllowPrivateAccess = "true"))
-	UCameraComponent* FollowCamera;
+        /** Follow camera */
+        UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category="Components", meta = (AllowPrivateAccess = "true"))
+        UCameraComponent* FollowCamera;
+
+        /** Handles audiovisual feedback when the world state changes */
+        UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category="World Shift", meta = (AllowPrivateAccess = "true"))
+        UWorldShiftEffectsComponent* WorldShiftEffects;
 	
 protected:
 
@@ -60,8 +65,10 @@ public:
 
 protected:
 
-	/** Initialize input action bindings */
-	virtual void SetupPlayerInputComponent(class UInputComponent* PlayerInputComponent) override;
+        virtual void BeginPlay() override;
+
+        /** Initialize input action bindings */
+        virtual void SetupPlayerInputComponent(class UInputComponent* PlayerInputComponent) override;
 
 protected:
 


### PR DESCRIPTION
## Summary
- add a WorldShiftEffects component to the player character so designers can configure world shift feedback
- bind the component to the world manager's shift delegate at BeginPlay with safety checks

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df650204a8832eabdd30d4d1bb418f