### PR TITLE
Clamp mouse wheel world cycling to a single step

### DIFF
--- a/Source/GameJam/GameJamCharacter.cpp
+++ b/Source/GameJam/GameJamCharacter.cpp
@@ -134,14 +134,20 @@ void AGameJamCharacter::CycleWorld(const FInputActionValue& Value)
         {
                 if (AWorldManager* WorldManager = AWorldManager::Get(World))
                 {
+                        const int32 NumWorlds = static_cast<int32>(EWorldState::Chaos) + 1;
+                        int32 CurrentIndex = static_cast<int32>(WorldManager->GetCurrentWorld());
+
                         if (AxisValue > 0.0f)
                         {
-                                WorldManager->ShiftToNextWorld();
+                                CurrentIndex = (CurrentIndex + 1) % NumWorlds;
                         }
-                        else
+                        else if (AxisValue < 0.0f)
                         {
-                                WorldManager->ShiftToPreviousWorld();
+                                CurrentIndex = (CurrentIndex - 1 + NumWorlds) % NumWorlds;
                         }
+
+                        const EWorldState NewWorld = static_cast<EWorldState>(CurrentIndex);
+                        WorldManager->SetWorld(NewWorld);
                 }
         }
 }


### PR DESCRIPTION
## Summary
- clamp mouse wheel world cycling to a single enum step per input by wrapping indices manually

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df75e9ab30832eb5b2cbe72e3dc8f9