### PR TITLE
Add UI widgets for layout, world indicator, and health bar

### DIFF
--- a/Source/GameJam/Widget_HealthBar.cpp
+++ b/Source/GameJam/Widget_HealthBar.cpp
@@ -1,0 +1,27 @@
+#include "Widget_HealthBar.h"
+
+#include "Components/ProgressBar.h"
+
+void UWidget_HealthBar::UpdateHealth(float NewHealth, float MaxHealth)
+{
+    if (!HealthProgress || MaxHealth <= 0.0f)
+    {
+        return;
+    }
+
+    const float Percent = FMath::Clamp(NewHealth / MaxHealth, 0.0f, 1.0f);
+    HealthProgress->SetPercent(Percent);
+
+    FLinearColor BarColor = FLinearColor::Red;
+
+    if (Percent > 0.6f)
+    {
+        BarColor = FLinearColor::Green;
+    }
+    else if (Percent > 0.2f)
+    {
+        BarColor = FLinearColor::Yellow;
+    }
+
+    HealthProgress->SetFillColorAndOpacity(BarColor);
+}

--- a/Source/GameJam/Widget_HealthBar.h
+++ b/Source/GameJam/Widget_HealthBar.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
+#include "Widget_HealthBar.generated.h"
+
+class UProgressBar;
+
+/**
+ * Displays the player's remaining health in response to world shift drain events.
+ */
+UCLASS(Blueprintable)
+class GAMEJAM_API UWidget_HealthBar : public UUserWidget
+{
+    GENERATED_BODY()
+
+public:
+    /** Progress bar representing the player's current health percentage. */
+    UPROPERTY(BlueprintReadWrite, meta = (BindWidgetOptional))
+    UProgressBar* HealthProgress;
+
+    /** Updates the progress bar and color based on the provided health values. */
+    UFUNCTION(BlueprintCallable)
+    void UpdateHealth(float NewHealth, float MaxHealth);
+};

--- a/Source/GameJam/Widget_Layout.h
+++ b/Source/GameJam/Widget_Layout.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
+#include "Widget_Layout.generated.h"
+
+class UWidget_HealthBar;
+class UWidget_WorldIndicator;
+
+/**
+ * Root HUD layout widget that exposes references to key UI elements for blueprint wiring.
+ */
+UCLASS(Blueprintable)
+class GAMEJAM_API UWidget_Layout : public UUserWidget
+{
+    GENERATED_BODY()
+
+public:
+    /** Visual indicator for the currently active world. */
+    UPROPERTY(BlueprintReadWrite, meta = (BindWidgetOptional))
+    UWidget_WorldIndicator* WorldIndicator;
+
+    /** Health display that reacts to damage inflicted by world shifts. */
+    UPROPERTY(BlueprintReadWrite, meta = (BindWidgetOptional))
+    UWidget_HealthBar* HealthBar;
+};

--- a/Source/GameJam/Widget_WorldIndicator.cpp
+++ b/Source/GameJam/Widget_WorldIndicator.cpp
@@ -1,0 +1,28 @@
+#include "Widget_WorldIndicator.h"
+
+#include "Components/Image.h"
+
+void UWidget_WorldIndicator::UpdateWorldIcon(EWorldState NewWorld)
+{
+    const int32 IconIndex = static_cast<int32>(NewWorld);
+
+    if (WorldImage && WorldIcons.IsValidIndex(IconIndex))
+    {
+        if (UTexture2D* Texture = WorldIcons[IconIndex])
+        {
+            WorldImage->SetBrushFromTexture(Texture, true);
+        }
+    }
+
+    if (WorldImage)
+    {
+        if (const FString* const WorldName = WorldNames.Find(NewWorld))
+        {
+            WorldImage->SetToolTipText(FText::FromString(*WorldName));
+        }
+        else
+        {
+            WorldImage->SetToolTipText(FText::GetEmpty());
+        }
+    }
+}

--- a/Source/GameJam/Widget_WorldIndicator.h
+++ b/Source/GameJam/Widget_WorldIndicator.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
+#include "WorldShiftTypes.h"
+#include "Widget_WorldIndicator.generated.h"
+
+class UImage;
+class UTexture2D;
+
+/**
+ * Displays the icon associated with the currently active world state.
+ */
+UCLASS(Blueprintable)
+class GAMEJAM_API UWidget_WorldIndicator : public UUserWidget
+{
+    GENERATED_BODY()
+
+public:
+    /** Textures indexed by the world state enum value. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "World")
+    TArray<TObjectPtr<UTexture2D>> WorldIcons;
+
+    /** Image widget that renders the selected world texture. */
+    UPROPERTY(BlueprintReadWrite, meta = (BindWidgetOptional))
+    TObjectPtr<UImage> WorldImage;
+
+    /** Friendly names used as tooltips for each world state. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "World")
+    TMap<EWorldState, FString> WorldNames;
+
+    /** Updates the icon and tooltip when the world changes. */
+    UFUNCTION(BlueprintCallable)
+    void UpdateWorldIcon(EWorldState NewWorld);
+};


### PR DESCRIPTION
## Summary
- add a layout widget that exposes the world indicator and health bar for blueprint wiring
- implement a world indicator widget to update its icon and tooltip when the world changes
- implement a health bar widget that updates its fill amount and color from health values

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3d84b91ac832eb3d48c4b0911e925