### PR TITLE
Refactor layout widget to spawn world widget

### DIFF
--- a/Source/GameJam/Widget_Layout.cpp
+++ b/Source/GameJam/Widget_Layout.cpp
@@ -1,0 +1,17 @@
+#include "Widget_Layout.h"
+
+#include "WorldWidget.h"
+
+void UWidget_Layout::NativeConstruct()
+{
+    Super::NativeConstruct();
+
+    if (!WorldWidgetInstance && WorldWidgetClass)
+    {
+        WorldWidgetInstance = CreateWidget<UWorldWidget>(GetWorld(), WorldWidgetClass);
+        if (WorldWidgetInstance)
+        {
+            WorldWidgetInstance->AddToViewport();
+        }
+    }
+}

--- a/Source/GameJam/Widget_Layout.h
+++ b/Source/GameJam/Widget_Layout.h
@@ -6,6 +6,7 @@
 
 class UWidget_HealthBar;
 class UWidget_WorldIndicator;
+class UWorldWidget;
 
 /**
  * Root HUD layout widget that exposes references to key UI elements for blueprint wiring.
@@ -23,4 +24,14 @@ public:
     /** Health display that reacts to damage inflicted by world shifts. */
     UPROPERTY(BlueprintReadWrite, meta = (BindWidgetOptional))
     UWidget_HealthBar* HealthBar;
+
+    /** Blueprint-assigned class responsible for rendering world widgets. */
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="World")
+    TSubclassOf<class UWorldWidget> WorldWidgetClass;
+
+    /** Instance of the world widget spawned at runtime. */
+    UPROPERTY(BlueprintReadWrite)
+    TObjectPtr<UWorldWidget> WorldWidgetInstance;
+
+    virtual void NativeConstruct() override;
 };


### PR DESCRIPTION
## Summary
- add blueprint-assignable world widget class and instance tracking to `UWidget_Layout`
- spawn the configured world widget during construct and add it to the viewport

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3ec115544832ead86a05ec38c6060