### PR TITLE
Refactor health handling with dedicated component

### DIFF
--- a/Source/GameJam/HealthComponent.cpp
+++ b/Source/GameJam/HealthComponent.cpp
@@ -1,0 +1,76 @@
+#include "HealthComponent.h"
+
+#include "GameFramework/Actor.h"
+
+UHealthComponent::UHealthComponent()
+{
+    PrimaryComponentTick.bCanEverTick = false;
+    CurrentHealth = FMath::Clamp(CurrentHealth, 0.f, MaxHealth);
+}
+
+void UHealthComponent::BeginPlay()
+{
+    Super::BeginPlay();
+    ClampToValidRange();
+    OnHealthChanged.Broadcast(CurrentHealth, MaxHealth);
+}
+
+void UHealthComponent::ClampToValidRange()
+{
+    CurrentHealth = FMath::Clamp(CurrentHealth, 0.f, MaxHealth);
+}
+
+void UHealthComponent::BroadcastIfChanged(float Old, float OldMax)
+{
+    if (!FMath::IsNearlyEqual(Old, CurrentHealth) || !FMath::IsNearlyEqual(OldMax, MaxHealth))
+    {
+        OnHealthChanged.Broadcast(CurrentHealth, MaxHealth);
+        if (CurrentHealth <= 0.f && Old > 0.f)
+        {
+            OnDied.Broadcast();
+        }
+    }
+}
+
+bool UHealthComponent::ApplyHealthDelta(float Delta)
+{
+    if (FMath::IsNearlyZero(Delta))
+    {
+        return false;
+    }
+
+    const float Old = CurrentHealth;
+    const float OldMax = MaxHealth;
+    CurrentHealth = FMath::Clamp(CurrentHealth + Delta, 0.f, MaxHealth);
+    BroadcastIfChanged(Old, OldMax);
+    return !FMath::IsNearlyEqual(Old, CurrentHealth);
+}
+
+bool UHealthComponent::ApplyDamage(float Damage)
+{
+    if (Damage <= 0.f)
+    {
+        return false;
+    }
+
+    return ApplyHealthDelta(-Damage);
+}
+
+bool UHealthComponent::Heal(float Amount)
+{
+    if (Amount <= 0.f)
+    {
+        return false;
+    }
+
+    return ApplyHealthDelta(Amount);
+}
+
+bool UHealthComponent::SetHealth(float NewHealth)
+{
+    const float Old = CurrentHealth;
+    const float OldMax = MaxHealth;
+    CurrentHealth = FMath::Clamp(NewHealth, 0.f, MaxHealth);
+    BroadcastIfChanged(Old, OldMax);
+    return !FMath::IsNearlyEqual(Old, CurrentHealth);
+}

--- a/Source/GameJam/HealthComponent.h
+++ b/Source/GameJam/HealthComponent.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+#include "HealthComponent.generated.h"
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnHealthChanged, float, NewHealth, float, MaxHealth);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnDied);
+
+UCLASS(ClassGroup=(Game), meta=(BlueprintSpawnableComponent))
+class GAMEJAM_API UHealthComponent : public UActorComponent
+{
+    GENERATED_BODY()
+
+public:
+    UHealthComponent();
+
+    /** Maximum health. */
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Health")
+    float MaxHealth = 100.f;
+
+    /** Current health (clamped to [0, MaxHealth]). */
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Health")
+    float CurrentHealth = 100.f;
+
+    /** Broadcast on any health change (after clamping). */
+    UPROPERTY(BlueprintAssignable, Category="Health")
+    FOnHealthChanged OnHealthChanged;
+
+    /** Broadcast once when health reaches zero. */
+    UPROPERTY(BlueprintAssignable, Category="Health")
+    FOnDied OnDied;
+
+    /** Add a signed delta to health (negative = damage). Returns true if changed. */
+    UFUNCTION(BlueprintCallable, Category="Health")
+    bool ApplyHealthDelta(float Delta);
+
+    /** Explicit damage (positive value). Returns true if changed. */
+    UFUNCTION(BlueprintCallable, Category="Health")
+    bool ApplyDamage(float Damage);
+
+    /** Explicit heal (positive value). Returns true if changed. */
+    UFUNCTION(BlueprintCallable, Category="Health")
+    bool Heal(float Amount);
+
+    /** Set absolute health value (clamped). Returns true if changed. */
+    UFUNCTION(BlueprintCallable, Category="Health")
+    bool SetHealth(float NewHealth);
+
+    /** Getters */
+    UFUNCTION(BlueprintPure, Category="Health")
+    float GetHealth() const { return CurrentHealth; }
+
+    UFUNCTION(BlueprintPure, Category="Health")
+    float GetMaxHealth() const { return MaxHealth; }
+
+    UFUNCTION(BlueprintPure, Category="Health")
+    bool IsAlive() const { return CurrentHealth > 0.f; }
+
+protected:
+    virtual void BeginPlay() override;
+
+private:
+    void BroadcastIfChanged(float Old, float OldMax);
+    void ClampToValidRange();
+};

--- a/Source/GameJam/Widget_Layout.cpp
+++ b/Source/GameJam/Widget_Layout.cpp
@@ -2,6 +2,12 @@
 
 #include "WorldWidget.h"
 
+#include "GameFramework/Pawn.h"
+#include "GameFramework/PlayerController.h"
+#include "HealthComponent.h"
+#include "Widget_HealthBar.h"
+#include "WorldShiftEffectsComponent.h"
+
 void UWidget_Layout::NativeConstruct()
 {
     Super::NativeConstruct();
@@ -12,6 +18,32 @@ void UWidget_Layout::NativeConstruct()
         if (WorldWidgetInstance)
         {
             WorldWidgetInstance->AddToViewport();
+        }
+    }
+
+    if (HealthBar)
+    {
+        if (APlayerController* OwningController = GetOwningPlayer())
+        {
+            if (APawn* Pawn = OwningController->GetPawn())
+            {
+                if (UWorldShiftEffectsComponent* Effects = Pawn->FindComponentByClass<UWorldShiftEffectsComponent>())
+                {
+                    if (!Effects->OnHealthDrained.IsAlreadyBound(HealthBar, &UWidget_HealthBar::UpdateHealth))
+                    {
+                        Effects->OnHealthDrained.AddDynamic(HealthBar, &UWidget_HealthBar::UpdateHealth);
+                    }
+                }
+
+                if (UHealthComponent* HealthComponent = Pawn->FindComponentByClass<UHealthComponent>())
+                {
+                    if (!HealthComponent->OnHealthChanged.IsAlreadyBound(HealthBar, &UWidget_HealthBar::UpdateHealth))
+                    {
+                        HealthComponent->OnHealthChanged.AddDynamic(HealthBar, &UWidget_HealthBar::UpdateHealth);
+                    }
+                    HealthBar->UpdateHealth(HealthComponent->GetHealth(), HealthComponent->GetMaxHealth());
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a reusable HealthComponent for clamped health tracking and events
- refactor WorldShiftEffectsComponent to consume the HealthComponent and simplify health draining
- bind the HUD health bar to both world-shift health drain and global health change events

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4013ddc24832ea88b5e0a315b2e30