### PR TITLE
Add Niagara finish callback for world shift effects

### DIFF
--- a/Source/GameJam/WorldShiftEffectsComponent.cpp
+++ b/Source/GameJam/WorldShiftEffectsComponent.cpp
@@ -6,6 +6,7 @@
 #include "GameFramework/PlayerController.h"
 #include "HealthComponent.h"
 #include "Kismet/GameplayStatics.h"
+#include "NiagaraComponent.h"
 #include "NiagaraFunctionLibrary.h"
 #include "NiagaraSystem.h"
 #include "Sound/SoundBase.h"
@@ -52,7 +53,20 @@ void UWorldShiftEffectsComponent::TriggerWorldShiftEffects(EWorldState NewWorld)
         {
             if (UWorld* World = GetWorld())
             {
-                UNiagaraFunctionLibrary::SpawnSystemAtLocation(World, ParticleSystem, Owner->GetActorLocation(), Owner->GetActorRotation());
+                UNiagaraComponent* NiagaraComp = UNiagaraFunctionLibrary::SpawnSystemAtLocation(
+                    World,
+                    ParticleSystem,
+                    Owner->GetActorLocation(),
+                    Owner->GetActorRotation(),
+                    FVector(1.f),
+                    true,
+                    true,
+                    ENCPoolMethod::AutoRelease);
+
+                if (NiagaraComp)
+                {
+                    NiagaraComp->OnSystemFinished.AddDynamic(this, &UWorldShiftEffectsComponent::OnNiagaraEffectFinished);
+                }
             }
         }
     }
@@ -118,4 +132,14 @@ UHealthComponent* UWorldShiftEffectsComponent::FindHealthComponentOnOwner() cons
     }
 
     return nullptr;
+}
+
+void UWorldShiftEffectsComponent::OnNiagaraEffectFinished(UNiagaraComponent* FinishedComponent)
+{
+    if (!FinishedComponent)
+    {
+        return;
+    }
+
+    UE_LOG(LogTemp, Log, TEXT("Niagara effect finished: %s"), *FinishedComponent->GetName());
 }

--- a/Source/GameJam/WorldShiftEffectsComponent.h
+++ b/Source/GameJam/WorldShiftEffectsComponent.h
@@ -8,6 +8,7 @@
 
 class UHealthComponent;
 class USoundBase;
+class UNiagaraComponent;
 class UNiagaraSystem;
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnWorldShiftTriggered, EWorldState, NewWorld);
@@ -51,6 +52,9 @@ public:
     /** Triggers all configured effects for the provided world state. */
     UFUNCTION(BlueprintCallable, Category = "World Shift|Effects")
     void TriggerWorldShiftEffects(EWorldState NewWorld);
+
+    UFUNCTION()
+    void OnNiagaraEffectFinished(UNiagaraComponent* FinishedComponent);
 
 protected:
     virtual void BeginPlay() override;


### PR DESCRIPTION
## Summary
- spawn Niagara systems for world shifts with auto-destroying one-shot components and bind a finish delegate
- add a callback handler that currently logs effect completion to support follow-up logic

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e424c19208832ea2bc02ca01739842