### PR TITLE
Add world-shifting door actor

### DIFF
--- a/Source/GameJam/WorldDoor.cpp
+++ b/Source/GameJam/WorldDoor.cpp
@@ -1,0 +1,92 @@
+#include "WorldDoor.h"
+
+#include "WorldManager.h"
+#include "WorldShiftComponent.h"
+#include "Components/StaticMeshComponent.h"
+#include "Kismet/GameplayStatics.h"
+#include "Sound/SoundBase.h"
+
+AWorldDoor::AWorldDoor()
+{
+    PrimaryActorTick.bCanEverTick = false;
+
+    DoorMesh = CreateDefaultSubobject<UStaticMeshComponent>(TEXT("DoorMesh"));
+    RootComponent = DoorMesh;
+
+    WorldShiftComponent = CreateDefaultSubobject<UWorldShiftComponent>(TEXT("WorldShiftComponent"));
+
+    DoorMesh->SetCollisionProfileName(TEXT("BlockAll"));
+    DoorMesh->SetGenerateOverlapEvents(false);
+
+    bAnimateOnToggle = true;
+    bIsCurrentlyVisible = true;
+    bHasInitialized = false;
+}
+
+void AWorldDoor::BeginPlay()
+{
+    Super::BeginPlay();
+
+    if (WorldShiftComponent)
+    {
+        WorldShiftComponent->OnWorldShifted.AddDynamic(this, &AWorldDoor::HandleWorldShift);
+    }
+
+    if (AWorldManager* Manager = AWorldManager::Get(GetWorld()))
+    {
+        HandleWorldShift(Manager->GetCurrentWorld());
+    }
+    else
+    {
+        const bool bShouldBeVisible = VisibleInWorlds.Contains(EWorldState::Light);
+        SetDoorState(bShouldBeVisible);
+    }
+}
+
+void AWorldDoor::HandleWorldShift(EWorldState NewWorld)
+{
+    const bool bShouldBeVisible = VisibleInWorlds.Contains(NewWorld);
+    SetDoorState(bShouldBeVisible);
+}
+
+void AWorldDoor::SetDoorState(bool bShouldBeVisible)
+{
+    if (bHasInitialized && bIsCurrentlyVisible == bShouldBeVisible)
+    {
+        return;
+    }
+
+    bHasInitialized = true;
+    bIsCurrentlyVisible = bShouldBeVisible;
+
+    if (DoorMesh)
+    {
+        DoorMesh->SetHiddenInGame(!bShouldBeVisible);
+        DoorMesh->SetCollisionEnabled(bShouldBeVisible ? ECollisionEnabled::QueryAndPhysics : ECollisionEnabled::NoCollision);
+    }
+
+    if (bAnimateOnToggle)
+    {
+        PlayDoorAnimation(bShouldBeVisible);
+    }
+
+    if (bShouldBeVisible && OpenSound)
+    {
+        UGameplayStatics::PlaySoundAtLocation(this, OpenSound, GetActorLocation());
+    }
+    else if (!bShouldBeVisible && CloseSound)
+    {
+        UGameplayStatics::PlaySoundAtLocation(this, CloseSound, GetActorLocation());
+    }
+}
+
+void AWorldDoor::PlayDoorAnimation(bool bOpening)
+{
+    if (!DoorMesh)
+    {
+        return;
+    }
+
+    const FRotator TargetRotation = bOpening ? FRotator(0.f, 90.f, 0.f) : FRotator::ZeroRotator;
+    DoorMesh->SetRelativeRotation(TargetRotation);
+}

--- a/Source/GameJam/WorldDoor.h
+++ b/Source/GameJam/WorldDoor.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "WorldShiftTypes.h"
+#include "WorldDoor.generated.h"
+
+class UStaticMeshComponent;
+class UWorldShiftComponent;
+class USoundBase;
+
+/**
+ * Actor representing a world-dependent door that toggles visibility and collision
+ * when the active world changes.
+ */
+UCLASS()
+class GAMEJAM_API AWorldDoor : public AActor
+{
+    GENERATED_BODY()
+
+public:
+    AWorldDoor();
+
+protected:
+    virtual void BeginPlay() override;
+
+    /** Mesh for the door */
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Components")
+    TObjectPtr<UStaticMeshComponent> DoorMesh;
+
+    /** World-shift behavior component */
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Components")
+    TObjectPtr<UWorldShiftComponent> WorldShiftComponent;
+
+    /** Optional sound when door opens */
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Audio")
+    TObjectPtr<USoundBase> OpenSound;
+
+    /** Optional sound when door closes */
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Audio")
+    TObjectPtr<USoundBase> CloseSound;
+
+    /** Worlds where the door should be visible and solid */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "World")
+    TArray<EWorldState> VisibleInWorlds;
+
+    /** Whether the door should auto-play open/close animation on toggle */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Door Behavior")
+    bool bAnimateOnToggle;
+
+private:
+    UFUNCTION()
+    void HandleWorldShift(EWorldState NewWorld);
+
+    void SetDoorState(bool bShouldBeVisible);
+    void PlayDoorAnimation(bool bOpening);
+
+    bool bIsCurrentlyVisible;
+    bool bHasInitialized;
+};

--- a/Source/GameJam/WorldShiftComponent.cpp
+++ b/Source/GameJam/WorldShiftComponent.cpp
@@ -63,5 +63,5 @@ void UWorldShiftComponent::HandleWorldShift(EWorldState NewWorld)
 }
 void UWorldShiftComponent::OnWorldShift(EWorldState NewWorld)
 {
-
+    OnWorldShifted.Broadcast(NewWorld);
 }

--- a/Source/GameJam/WorldShiftComponent.h
+++ b/Source/GameJam/WorldShiftComponent.h
@@ -7,6 +7,8 @@
 
 class AWorldManager;
 
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnWorldShiftComponentSignature, EWorldState, NewWorld);
+
 UCLASS(ClassGroup = (WorldShift), meta = (BlueprintSpawnableComponent))
 class GAMEJAM_API UWorldShiftComponent : public UActorComponent
 {
@@ -18,8 +20,12 @@ public:
     UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "World Shift")
     TArray<EWorldState> VisibleInWorlds;
 
+    /** Broadcast when the world shifts. */
+    UPROPERTY(BlueprintAssignable, Category = "World Shift")
+    FOnWorldShiftComponentSignature OnWorldShifted;
+
     UFUNCTION(BlueprintCallable, Category = "World Shift")
-    void OnWorldShift(EWorldState NewWorld);
+    virtual void OnWorldShift(EWorldState NewWorld);
 
 protected:
     virtual void OnRegister() override;


### PR DESCRIPTION
## Summary
- add an AWorldDoor actor that toggles its mesh visibility, collision, and optional sounds when the active world changes
- expose a multicast delegate on UWorldShiftComponent so actors like the door can respond to world shifts

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e56afebb3c832ebc120de489febdde