### PR TITLE
Add world-sensitive health pickup actor

### DIFF
--- a/Source/GameJam/HealthPickup.cpp
+++ b/Source/GameJam/HealthPickup.cpp
@@ -1,0 +1,70 @@
+#include "HealthPickup.h"
+
+#include "Components/SphereComponent.h"
+#include "Components/StaticMeshComponent.h"
+#include "HealthComponent.h"
+#include "Kismet/GameplayStatics.h"
+#include "Sound/SoundBase.h"
+#include "WorldShiftBehaviorComponent.h"
+#include "ShiftPlatform.h"
+
+AHealthPickup::AHealthPickup()
+{
+    PrimaryActorTick.bCanEverTick = false;
+
+    CollisionSphere = CreateDefaultSubobject<USphereComponent>(TEXT("CollisionSphere"));
+    CollisionSphere->InitSphereRadius(50.f);
+    RootComponent = CollisionSphere;
+    CollisionSphere->SetCollisionProfileName(TEXT("OverlapAllDynamic"));
+
+    PickupMesh = CreateDefaultSubobject<UStaticMeshComponent>(TEXT("PickupMesh"));
+    PickupMesh->SetupAttachment(RootComponent);
+    PickupMesh->SetCollisionEnabled(ECollisionEnabled::NoCollision);
+
+    WorldShiftBehavior = CreateDefaultSubobject<UWorldShiftBehaviorComponent>(TEXT("WorldShiftBehavior"));
+    if (WorldShiftBehavior)
+    {
+        WorldShiftBehavior->SetTargetMesh(PickupMesh);
+    }
+
+    CollisionSphere->OnComponentBeginOverlap.AddDynamic(this, &AHealthPickup::OnOverlapBegin);
+}
+
+void AHealthPickup::BeginPlay()
+{
+    Super::BeginPlay();
+}
+
+bool AHealthPickup::CanBeCollected() const
+{
+    if (!WorldShiftBehavior)
+    {
+        return true;
+    }
+
+    return WorldShiftBehavior->CurrentState == EPlatformState::Solid;
+}
+
+void AHealthPickup::OnOverlapBegin(UPrimitiveComponent* OverlappedComp, AActor* OtherActor,
+                                   UPrimitiveComponent* OtherComp, int32 OtherBodyIndex, bool bFromSweep, const FHitResult& SweepResult)
+{
+    if (!CanBeCollected() || !OtherActor)
+    {
+        return;
+    }
+
+    if (UHealthComponent* HealthComp = OtherActor->FindComponentByClass<UHealthComponent>())
+    {
+        const bool bChanged = HealthComp->Heal(HealthAmount);
+
+        if (bChanged)
+        {
+            if (PickupSound)
+            {
+                UGameplayStatics::PlaySoundAtLocation(this, PickupSound, GetActorLocation());
+            }
+
+            Destroy();
+        }
+    }
+}

--- a/Source/GameJam/HealthPickup.h
+++ b/Source/GameJam/HealthPickup.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "HealthPickup.generated.h"
+
+class USphereComponent;
+class UStaticMeshComponent;
+class UWorldShiftBehaviorComponent;
+class USoundBase;
+class UHealthComponent;
+
+UCLASS()
+class GAMEJAM_API AHealthPickup : public AActor
+{
+    GENERATED_BODY()
+
+public:
+    AHealthPickup();
+
+protected:
+    virtual void BeginPlay() override;
+
+    /** Collision for overlap detection */
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Components")
+    TObjectPtr<USphereComponent> CollisionSphere;
+
+    /** Visual mesh */
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Components")
+    TObjectPtr<UStaticMeshComponent> PickupMesh;
+
+    /** World behavior component that defines Solid/Ghost/etc. */
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "World")
+    TObjectPtr<UWorldShiftBehaviorComponent> WorldShiftBehavior;
+
+    /** Pickup sound */
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Audio")
+    TObjectPtr<USoundBase> PickupSound;
+
+    /** Amount of health to add */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Health")
+    float HealthAmount = 10.f;
+
+private:
+    /** Handle player overlap */
+    UFUNCTION()
+    void OnOverlapBegin(UPrimitiveComponent* OverlappedComp, AActor* OtherActor,
+                        UPrimitiveComponent* OtherComp, int32 OtherBodyIndex, bool bFromSweep, const FHitResult& SweepResult);
+
+    /** Checks if the pickup is currently collectible */
+    bool CanBeCollected() const;
+};


### PR DESCRIPTION
## Summary
- add a reusable health pickup actor that registers overlap detection and plays audio on collection
- integrate the pickup with the world shift behavior so it can only be collected during solid states

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e56be2d210832e9a517f7b5f2ad9d9