### PR TITLE
Refactor world door to use shift behavior component states

### DIFF
--- a/Source/GameJam/WorldDoor.cpp
+++ b/Source/GameJam/WorldDoor.cpp
@@ -1,7 +1,8 @@
 #include "WorldDoor.h"
 
+#include "ShiftPlatform.h"
 #include "WorldManager.h"
-#include "WorldShiftComponent.h"
+#include "WorldShiftBehaviorComponent.h"
 #include "Components/StaticMeshComponent.h"
 #include "Kismet/GameplayStatics.h"
 #include "Sound/SoundBase.h"
@@ -13,68 +14,80 @@ AWorldDoor::AWorldDoor()
     DoorMesh = CreateDefaultSubobject<UStaticMeshComponent>(TEXT("DoorMesh"));
     RootComponent = DoorMesh;
 
-    WorldShiftComponent = CreateDefaultSubobject<UWorldShiftComponent>(TEXT("WorldShiftComponent"));
+    WorldShiftBehavior = CreateDefaultSubobject<UWorldShiftBehaviorComponent>(TEXT("WorldShiftBehavior"));
+    if (WorldShiftBehavior)
+    {
+        WorldShiftBehavior->SetTargetMesh(DoorMesh);
+    }
 
     DoorMesh->SetCollisionProfileName(TEXT("BlockAll"));
     DoorMesh->SetGenerateOverlapEvents(false);
 
     bAnimateOnToggle = true;
-    bIsCurrentlyVisible = true;
+    bIsCurrentlySolid = true;
     bHasInitialized = false;
+
+    SolidInWorlds = {EWorldState::Light};
 }
 
 void AWorldDoor::BeginPlay()
 {
     Super::BeginPlay();
 
-    if (WorldShiftComponent)
-    {
-        WorldShiftComponent->OnWorldShifted.AddDynamic(this, &AWorldDoor::HandleWorldShift);
-    }
+    InitializeWorldBehaviors();
 
     if (AWorldManager* Manager = AWorldManager::Get(GetWorld()))
     {
+        CachedWorldManager = Manager;
+        Manager->OnWorldShifted.AddDynamic(this, &AWorldDoor::HandleWorldShift);
         HandleWorldShift(Manager->GetCurrentWorld());
     }
     else
     {
-        const bool bShouldBeVisible = VisibleInWorlds.Contains(EWorldState::Light);
-        SetDoorState(bShouldBeVisible);
+        SetDoorState(IsSolidInWorld(EWorldState::Light));
     }
+}
+
+void AWorldDoor::EndPlay(const EEndPlayReason::Type EndPlayReason)
+{
+    if (CachedWorldManager.IsValid())
+    {
+        if (AWorldManager* Manager = CachedWorldManager.Get())
+        {
+            Manager->OnWorldShifted.RemoveDynamic(this, &AWorldDoor::HandleWorldShift);
+        }
+
+        CachedWorldManager.Reset();
+    }
+
+    Super::EndPlay(EndPlayReason);
 }
 
 void AWorldDoor::HandleWorldShift(EWorldState NewWorld)
 {
-    const bool bShouldBeVisible = VisibleInWorlds.Contains(NewWorld);
-    SetDoorState(bShouldBeVisible);
+    SetDoorState(IsSolidInWorld(NewWorld));
 }
 
-void AWorldDoor::SetDoorState(bool bShouldBeVisible)
+void AWorldDoor::SetDoorState(bool bShouldBeSolid)
 {
-    if (bHasInitialized && bIsCurrentlyVisible == bShouldBeVisible)
+    if (bHasInitialized && bIsCurrentlySolid == bShouldBeSolid)
     {
         return;
     }
 
     bHasInitialized = true;
-    bIsCurrentlyVisible = bShouldBeVisible;
-
-    if (DoorMesh)
-    {
-        DoorMesh->SetHiddenInGame(!bShouldBeVisible);
-        DoorMesh->SetCollisionEnabled(bShouldBeVisible ? ECollisionEnabled::QueryAndPhysics : ECollisionEnabled::NoCollision);
-    }
+    bIsCurrentlySolid = bShouldBeSolid;
 
     if (bAnimateOnToggle)
     {
-        PlayDoorAnimation(bShouldBeVisible);
+        PlayDoorAnimation(!bShouldBeSolid);
     }
 
-    if (bShouldBeVisible && OpenSound)
+    if (!bShouldBeSolid && OpenSound)
     {
         UGameplayStatics::PlaySoundAtLocation(this, OpenSound, GetActorLocation());
     }
-    else if (!bShouldBeVisible && CloseSound)
+    else if (bShouldBeSolid && CloseSound)
     {
         UGameplayStatics::PlaySoundAtLocation(this, CloseSound, GetActorLocation());
     }
@@ -89,4 +102,39 @@ void AWorldDoor::PlayDoorAnimation(bool bOpening)
 
     const FRotator TargetRotation = bOpening ? FRotator(0.f, 90.f, 0.f) : FRotator::ZeroRotator;
     DoorMesh->SetRelativeRotation(TargetRotation);
+}
+
+bool AWorldDoor::IsSolidInWorld(EWorldState World) const
+{
+    if (WorldShiftBehavior)
+    {
+        if (const EPlatformState* FoundState = WorldShiftBehavior->WorldBehaviors.Find(World))
+        {
+            return *FoundState == EPlatformState::Solid || *FoundState == EPlatformState::TimedSolid;
+        }
+    }
+
+    return SolidInWorlds.Contains(World);
+}
+
+void AWorldDoor::InitializeWorldBehaviors()
+{
+    if (!WorldShiftBehavior)
+    {
+        return;
+    }
+
+    WorldShiftBehavior->SetTargetMesh(DoorMesh);
+
+    if (WorldShiftBehavior->WorldBehaviors.Num() > 0)
+    {
+        return;
+    }
+
+    const TArray<EWorldState> AllWorlds = {EWorldState::Light, EWorldState::Shadow, EWorldState::Chaos};
+    for (EWorldState World : AllWorlds)
+    {
+        const bool bSolid = SolidInWorlds.Contains(World);
+        WorldShiftBehavior->WorldBehaviors.Add(World, bSolid ? EPlatformState::Solid : EPlatformState::Ghost);
+    }
 }

--- a/Source/GameJam/WorldDoor.h
+++ b/Source/GameJam/WorldDoor.h
@@ -6,8 +6,9 @@
 #include "WorldDoor.generated.h"
 
 class UStaticMeshComponent;
-class UWorldShiftComponent;
+class UWorldShiftBehaviorComponent;
 class USoundBase;
+class AWorldManager;
 
 /**
  * Actor representing a world-dependent door that toggles visibility and collision
@@ -23,6 +24,7 @@ public:
 
 protected:
     virtual void BeginPlay() override;
+    virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
 
     /** Mesh for the door */
     UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Components")
@@ -30,7 +32,7 @@ protected:
 
     /** World-shift behavior component */
     UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Components")
-    TObjectPtr<UWorldShiftComponent> WorldShiftComponent;
+    TObjectPtr<UWorldShiftBehaviorComponent> WorldShiftBehavior;
 
     /** Optional sound when door opens */
     UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Audio")
@@ -40,9 +42,9 @@ protected:
     UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Audio")
     TObjectPtr<USoundBase> CloseSound;
 
-    /** Worlds where the door should be visible and solid */
+    /** Worlds where the door should be solid (impassable). Other worlds will be passable. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "World")
-    TArray<EWorldState> VisibleInWorlds;
+    TArray<EWorldState> SolidInWorlds;
 
     /** Whether the door should auto-play open/close animation on toggle */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Door Behavior")
@@ -52,9 +54,14 @@ private:
     UFUNCTION()
     void HandleWorldShift(EWorldState NewWorld);
 
-    void SetDoorState(bool bShouldBeVisible);
+    void SetDoorState(bool bShouldBeSolid);
     void PlayDoorAnimation(bool bOpening);
 
-    bool bIsCurrentlyVisible;
+    bool IsSolidInWorld(EWorldState World) const;
+    void InitializeWorldBehaviors();
+
+    bool bIsCurrentlySolid;
     bool bHasInitialized;
+
+    TWeakObjectPtr<AWorldManager> CachedWorldManager;
 };


### PR DESCRIPTION
## Summary
- refactor the world door to use the world shift behavior component for managing per-world solidity
- initialize default solid worlds, bind to the world manager, and keep animations/sounds in sync with behavior changes

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e5717982f0832ea6e54738dbaea0b9