### PR TITLE
Adjust door opening rotation to respect initial orientation

### DIFF
--- a/Source/GameJam/WorldDoor.cpp
+++ b/Source/GameJam/WorldDoor.cpp
@@ -26,6 +26,7 @@ AWorldDoor::AWorldDoor()
     bAnimateOnToggle = true;
     bIsCurrentlySolid = true;
     bHasInitialized = false;
+    InitialDoorRotation = FRotator::ZeroRotator;
 
     SolidInWorlds = {EWorldState::Light};
 }
@@ -33,6 +34,11 @@ AWorldDoor::AWorldDoor()
 void AWorldDoor::BeginPlay()
 {
     Super::BeginPlay();
+
+    if (DoorMesh)
+    {
+        InitialDoorRotation = DoorMesh->GetRelativeRotation();
+    }
 
     InitializeWorldBehaviors();
 
@@ -100,7 +106,7 @@ void AWorldDoor::PlayDoorAnimation(bool bOpening)
         return;
     }
 
-    const FRotator TargetRotation = bOpening ? FRotator(0.f, 90.f, 0.f) : FRotator::ZeroRotator;
+    const FRotator TargetRotation = bOpening ? (InitialDoorRotation + FRotator(0.f, 90.f, 0.f)) : InitialDoorRotation;
     DoorMesh->SetRelativeRotation(TargetRotation);
 }
 

--- a/Source/GameJam/WorldDoor.h
+++ b/Source/GameJam/WorldDoor.h
@@ -64,4 +64,5 @@ private:
     bool bHasInitialized;
 
     TWeakObjectPtr<AWorldManager> CachedWorldManager;
+    FRotator InitialDoorRotation;
 };


### PR DESCRIPTION
## Summary
- store the door's initial mesh rotation when play begins
- rotate the open state relative to the initial rotation rather than fixed axes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e57987b6d0832eba2853cafcd1ee5c