### PR TITLE
Add Blueprint event for manual time shift activation

### DIFF
--- a/Source/GameJam/GameJamCharacter.cpp
+++ b/Source/GameJam/GameJamCharacter.cpp
@@ -206,6 +206,8 @@ void AGameJamCharacter::OnShiftPressed()
                 {
                         Manager->SetWorld(EWorldState::Chaos);
                         bChaosShiftActive = true;
+
+                        OnTimeShiftStarted();
                 }
         }
 }

--- a/Source/GameJam/GameJamCharacter.h
+++ b/Source/GameJam/GameJamCharacter.h
@@ -118,6 +118,10 @@ protected:
         /** Handles returning to the Light world when the shift input is released. */
         void OnShiftReleased();
 
+        /** Event fired when a manual time shift into Chaos begins. */
+        UFUNCTION(BlueprintImplementableEvent, Category="World Shift|Input")
+        void OnTimeShiftStarted();
+
         /** Called for interact input. */
         void Interact(const FInputActionValue& Value);
 


### PR DESCRIPTION
## Summary
- add a BlueprintImplementableEvent to `AGameJamCharacter` for manual Chaos shifts
- invoke the new event when the shift input successfully transitions the world to Chaos

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fa6fb3b5a8832eb7d4197d4f4c4000