### PR TITLE
Add world reset broadcast to AWorldManager

### DIFF
--- a/Source/GameJam/WorldManager.cpp
+++ b/Source/GameJam/WorldManager.cpp
@@ -227,6 +227,8 @@ void AWorldManager::ResetWorld()
     }
 
     StartGlobalTimedSolidCycle();
+
+    OnWorldReset.Broadcast();
 }
 
 void AWorldManager::ApplyWorldFeedback(EWorldState NewWorld)

--- a/Source/GameJam/WorldManager.h
+++ b/Source/GameJam/WorldManager.h
@@ -15,6 +15,7 @@ struct FTimerHandle;
 
 /** Enum describing the three available world states. */
 
+DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnWorldReset);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnWorldShifted, EWorldState, NewWorld);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnTimedSolidPhaseChanged, bool, bNowSolid);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnTimedSolidPreWarning, bool, bWillBeSolid);
@@ -65,6 +66,10 @@ public:
     /** Broadcast when the world changes. */
     UPROPERTY(BlueprintAssignable, Category = "World Shift")
     FOnWorldShifted OnWorldShifted;
+
+    /** Broadcast when the world is reset. */
+    UPROPERTY(BlueprintAssignable, Category = "World Shift|Reset")
+    FOnWorldReset OnWorldReset;
 
     /** Broadcast when the global timed solid phase changes between solid and ghost. */
     UPROPERTY(BlueprintAssignable, Category = "World Shift|Timed Solid")


### PR DESCRIPTION
## Summary
- declare a multicast delegate for world reset notifications
- expose an OnWorldReset BlueprintAssignable event on AWorldManager
- broadcast the event after ResetWorld finishes its logic

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fa7ee43a30832e82de9b75cdf88369